### PR TITLE
Hotfix: Identifier mapper config

### DIFF
--- a/src/microservices/Microservices.IdentifierMapper/App.config
+++ b/src/microservices/Microservices.IdentifierMapper/App.config
@@ -33,18 +33,5 @@
             </dependentAssembly>
         </assemblyBinding>
     </runtime>
-    <system.data>
-        <DbProviderFactories>
-            <remove invariant="Oracle.ManagedDataAccess.Client" />
-            <add name="ODP.NET, Managed Driver" invariant="Oracle.ManagedDataAccess.Client" description="Oracle Data Provider for .NET, Managed Driver" type="Oracle.ManagedDataAccess.Client.OracleClientFactory, Oracle.ManagedDataAccess, Version=4.122.18.3, Culture=neutral, PublicKeyToken=89b483f429c47342" />
-        </DbProviderFactories>
-    </system.data>
-    <oracle.manageddataaccess.client>
-        <version number="*">
-            <dataSources>
-                <dataSource alias="SampleDataSource" descriptor="(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ORCL))) " />
-            </dataSources>
-        </version>
-    </oracle.manageddataaccess.client>
-
 </configuration>
+


### PR DESCRIPTION
This fixes a bug causing the IdentifierMapper service to crash-out on connection to MySQL with the following message:

```shell
2019-11-28 18:23:14.4282|FATAL|IdentifierMapperHost|ProcessMessageImpl threw unhandled exception|System.TypeInitializationException: The type initializer for 'MySql.Data.MySqlClient.Replication.ReplicationManager' threw an exception. ---> System.TypeInitializationException: The type initializer for 'MySql.Data.MySqlClient.MySqlConfiguration' threw an exception. ---> System.Configuration.ConfigurationErrorsException: Configuration system failed to initialize ---> System.Configuration.ConfigurationErrorsException: Unrecognized configuration section system.data. (/home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/dist/linux-x64/IdentifierMapper.dll.config line 36)
   at System.Configuration.ConfigurationSchemaErrors.ThrowIfErrors(Boolean ignoreLocal)
   at System.Configuration.BaseConfigurationRecord.ThrowIfParseErrors(ConfigurationSchemaErrors schemaErrors)
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)
   --- End of inner exception stack trace ---
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)
   at System.Configuration.ClientConfigurationSystem.PrepareClientConfigSystem(String sectionName)
   at System.Configuration.ClientConfigurationSystem.System.Configuration.Internal.IInternalConfigSystem.GetSection(String sectionName)
   at System.Configuration.ConfigurationManager.GetSection(String sectionName)
   at MySql.Data.MySqlClient.MySqlConfiguration..cctor()
   --- End of inner exception stack trace ---
   at MySql.Data.MySqlClient.MySqlConfiguration.get_Settings()
   at MySql.Data.MySqlClient.Replication.ReplicationManager..cctor()
   --- End of inner exception stack trace ---
   at MySql.Data.MySqlClient.Replication.ReplicationManager.IsReplicationGroup(String groupName)
   at MySql.Data.MySqlClient.MySqlConnection.Open()
   at Microservices.IdentifierMapper.Execution.Swappers.TableLookupSwapper.GetSubstitutionFor(String toSwap, String& reason) in /home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/Execution/Swappers/TableLookupSwapper.cs:line 57
   at Microservices.IdentifierMapper.Messaging.IdentifierMapperQueueConsumer.SwapIdentifier(DicomFileMessage msg, String& reason) in /home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/Messaging/IdentifierMapperQueueConsumer.cs:line 120
   at Microservices.IdentifierMapper.Messaging.IdentifierMapperQueueConsumer.ProcessMessageImpl(IMessageHeader header, BasicDeliverEventArgs deliverArgs) in /home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/Messaging/IdentifierMapperQueueConsumer.cs:line 55
   at Smi.Common.Messaging.Consumer.ProcessMessage(BasicDeliverEventArgs deliverArgs) in /home/rkm/dev/smi/SmiServices/src/common/Smi.Common/Messaging/Consumer.cs:line 110
System.TypeInitializationException: The type initializer for 'MySql.Data.MySqlClient.MySqlConfiguration' threw an exception. ---> System.Configuration.ConfigurationErrorsException: Configuration system failed to initialize ---> System.Configuration.ConfigurationErrorsException: Unrecognized configuration section system.data. (/home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/dist/linux-x64/IdentifierMapper.dll.config line 36)
   at System.Configuration.ConfigurationSchemaErrors.ThrowIfErrors(Boolean ignoreLocal)
   at System.Configuration.BaseConfigurationRecord.ThrowIfParseErrors(ConfigurationSchemaErrors schemaErrors)
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)
   --- End of inner exception stack trace ---
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)
   at System.Configuration.ClientConfigurationSystem.PrepareClientConfigSystem(String sectionName)
   at System.Configuration.ClientConfigurationSystem.System.Configuration.Internal.IInternalConfigSystem.GetSection(String sectionName)
   at System.Configuration.ConfigurationManager.GetSection(String sectionName)
   at MySql.Data.MySqlClient.MySqlConfiguration..cctor()
   --- End of inner exception stack trace ---
   at MySql.Data.MySqlClient.MySqlConfiguration.get_Settings()
   at MySql.Data.MySqlClient.Replication.ReplicationManager..cctor()
System.Configuration.ConfigurationErrorsException: Configuration system failed to initialize ---> System.Configuration.ConfigurationErrorsException: Unrecognized configuration section system.data. (/home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/dist/linux-x64/IdentifierMapper.dll.config line 36)
   at System.Configuration.ConfigurationSchemaErrors.ThrowIfErrors(Boolean ignoreLocal)
   at System.Configuration.BaseConfigurationRecord.ThrowIfParseErrors(ConfigurationSchemaErrors schemaErrors)
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)
   --- End of inner exception stack trace ---
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)
   at System.Configuration.ClientConfigurationSystem.PrepareClientConfigSystem(String sectionName)
   at System.Configuration.ClientConfigurationSystem.System.Configuration.Internal.IInternalConfigSystem.GetSection(String sectionName)
   at System.Configuration.ConfigurationManager.GetSection(String sectionName)
   at MySql.Data.MySqlClient.MySqlConfiguration..cctor()
System.Configuration.ConfigurationErrorsException: Unrecognized configuration section system.data. (/home/rkm/dev/smi/SmiServices/src/microservices/Microservices.IdentifierMapper/dist/linux-x64/IdentifierMapper.dll.config line 36)           at System.Configuration.ConfigurationSchemaErrors.ThrowIfErrors(Boolean ignoreLocal)
   at System.Configuration.BaseConfigurationRecord.ThrowIfParseErrors(ConfigurationSchemaErrors schemaErrors)
   at System.Configuration.ClientConfigurationSystem.EnsureInit(String configKey)||
2019-11-28 18:23:14.5561| INFO|IdentifierMapperHost|Host Stop called: Fatal error in MicroserviceHost (ProcessMessageImpl threw unhandled exception)|||
2019-11-28 18:23:14.8487| INFO|IdentifierMapperHost|Host stop completed|||
```

The fix was to remove the sections from the App.config relating to OracleDB(?)

I was wondering if the App.config file actually needs to exist at all anymore? I removed it during testing, rebuilt, and everything still seemed to work fine!
