### PR TITLE
Feature/publishing refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ jobs:
     - cd dist
     - zip -r win-x64-$TRAVIS_TAG.zip ./win-x64
     - tar czf linux-x64-$TRAVIS_TAG.tar.gz ./linux-x64
+    - cd ..
     # TMP
     - ls -l ./dist/
     - du -sh ./dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,14 @@ jobs:
     - mvn -f $PARENT_POM -ntp install    
     after_success:
 #    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
-      - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
-      # TMP
-      - find . -type f -name "*.zip"
+    - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
+    - |
+      for filename in $(find ./src -name "*deploy-distribution.zip" -printf "%f\n")
+      do
+        base=$(ls $filename | awk -F'-' '{print $1}')
+        mv $filename dist/$base-${TRAVIS_TAG}.zip
+      done
+    - ls ./dist
     # deploy:
     #   provider: releases
     #   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,9 @@ jobs:
       do
         dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo
       done
-    - zip -r ./dist/win-x64-$TRAVIS_TAG.zip ./dist/win-x64
-    - tar zcf ./dist/linux-x64-$TRAVIS_TAG.tar.gz ./dist/linux-x64
+    - cd dist
+    - zip -r win-x64-$TRAVIS_TAG.zip ./win-x64
+    - tar czf linux-x64-$TRAVIS_TAG.tar.gz ./linux-x64
     # TMP
     - ls -l ./dist/
     - du -sh ./dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
+
 dist: bionic
+
+# Testing only!
+env:
+  - TRAVIS_TAG=test
+
+
 jobs:
   include:
   - language: csharp
@@ -48,20 +55,12 @@ jobs:
       do
         dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo
       done
-    # - zip ./releasesolution/bin/win-x64.zip ./releasesolution/bin/win
-    # - tar -zcf ./releasesolution/bin/linux-x64.tar.gz ./releasesolution/bin/linux
+    - zip -r ./dist/win-x64-$TRAVIS_TAG.zip ./dist/win-x64
+    - tar zcf ./dist/linux-x64-$TRAVIS_TAG.tar.gz ./dist/linux-x64
     # TMP
     - ls -l ./dist/
     - du -sh ./dist/*
-    deploy:
-      provider: releases
-      api_key:
-        secure: DdirbOkYUePnKisYPlqYOpyti2HQFWmSIwY5spWflTUglzEZbnp+Q3sEltTebdlWo18i9skz6P5seAAXbX2ye1c3EZhqEyirWMxz1lvGdlNoQGHhWK6x+suM1DrG6Uun5dmcG/CEpWhDpcEbF8xQ/revtyCHEJj4xK9TXUHyFFG/KrzKSLGtsiBG1BOPkHJr4CoHjcpLzpmDB2hn+pYENtl3Nk0EeKmJgWdY/BWctEmUmRAXgfwsO/ejm9IbC5mIy5KBxbIUco/mf2JEKQB1drwdbINMxJXkbx+mWZYiDJBo5CWuWIzNOxv0Z3+Kg+N2cSwPX833v+W5YRTHyef/7Dum1yUrD3T7LMLY+3EIeCoGvARfRnQbi+BM9n1rFobPy/PWHWYxYRDnhDEfXrMcAyH/66InlQIhUh7XD01oZLEbsdZAbGnEsv5Ttz3F9LaEpk3EfoGqLxOWkL50OCxw6Jk6TfxsNtMoLpK1g7Jp8sI/EkjxYISer7S5myzLhKtgbtBwI0RcKh/sUo2m69QX++1JYy6CeN7/EwRmV4zJLk0WgalJuxgNFYrdzPLvg09okgxr1stHZQ7a5RkLH+r8KzA/Lmj6vTQG9HB44lHvX1hMiD0v8aCii+/wfr9AZZlNHjYq8RuHsP5uQ5U5F8G9uMqfiVb75MOPKY7qdYCZZZg=
-      file_glob: true
-      file: releasesolution/bin/*.*
-      skip-cleanup: true
-      on:
-        tags: true
+
   - language: java
     env:
     - PARENT_POM=src/common/com.smi.microservices.parent/pom.xml
@@ -89,13 +88,16 @@ jobs:
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
         mv --parents $filename dist/$base-${TRAVIS_TAG}.zip
       done
-    - ls ./dist
-    # deploy:
-    #   provider: releases
-    #   api_key:
-    #     secure: DdirbOkYUePnKisYPlqYOpyti2HQFWmSIwY5spWflTUglzEZbnp+Q3sEltTebdlWo18i9skz6P5seAAXbX2ye1c3EZhqEyirWMxz1lvGdlNoQGHhWK6x+suM1DrG6Uun5dmcG/CEpWhDpcEbF8xQ/revtyCHEJj4xK9TXUHyFFG/KrzKSLGtsiBG1BOPkHJr4CoHjcpLzpmDB2hn+pYENtl3Nk0EeKmJgWdY/BWctEmUmRAXgfwsO/ejm9IbC5mIy5KBxbIUco/mf2JEKQB1drwdbINMxJXkbx+mWZYiDJBo5CWuWIzNOxv0Z3+Kg+N2cSwPX833v+W5YRTHyef/7Dum1yUrD3T7LMLY+3EIeCoGvARfRnQbi+BM9n1rFobPy/PWHWYxYRDnhDEfXrMcAyH/66InlQIhUh7XD01oZLEbsdZAbGnEsv5Ttz3F9LaEpk3EfoGqLxOWkL50OCxw6Jk6TfxsNtMoLpK1g7Jp8sI/EkjxYISer7S5myzLhKtgbtBwI0RcKh/sUo2m69QX++1JYy6CeN7/EwRmV4zJLk0WgalJuxgNFYrdzPLvg09okgxr1stHZQ7a5RkLH+r8KzA/Lmj6vTQG9HB44lHvX1hMiD0v8aCii+/wfr9AZZlNHjYq8RuHsP5uQ5U5F8G9uMqfiVb75MOPKY7qdYCZZZg=
-    #   file_glob: true
-    #   file: releasesolution/bin/*.*
-    #   skip-cleanup: true
-    #   on:
-    #     tags: true
+    # TMP
+    - ls -l ./dist
+    - du -sh ./dist/*
+
+deploy:
+      provider: releases
+      api_key:
+        secure: DdirbOkYUePnKisYPlqYOpyti2HQFWmSIwY5spWflTUglzEZbnp+Q3sEltTebdlWo18i9skz6P5seAAXbX2ye1c3EZhqEyirWMxz1lvGdlNoQGHhWK6x+suM1DrG6Uun5dmcG/CEpWhDpcEbF8xQ/revtyCHEJj4xK9TXUHyFFG/KrzKSLGtsiBG1BOPkHJr4CoHjcpLzpmDB2hn+pYENtl3Nk0EeKmJgWdY/BWctEmUmRAXgfwsO/ejm9IbC5mIy5KBxbIUco/mf2JEKQB1drwdbINMxJXkbx+mWZYiDJBo5CWuWIzNOxv0Z3+Kg+N2cSwPX833v+W5YRTHyef/7Dum1yUrD3T7LMLY+3EIeCoGvARfRnQbi+BM9n1rFobPy/PWHWYxYRDnhDEfXrMcAyH/66InlQIhUh7XD01oZLEbsdZAbGnEsv5Ttz3F9LaEpk3EfoGqLxOWkL50OCxw6Jk6TfxsNtMoLpK1g7Jp8sI/EkjxYISer7S5myzLhKtgbtBwI0RcKh/sUo2m69QX++1JYy6CeN7/EwRmV4zJLk0WgalJuxgNFYrdzPLvg09okgxr1stHZQ7a5RkLH+r8KzA/Lmj6vTQG9HB44lHvX1hMiD0v8aCii+/wfr9AZZlNHjYq8RuHsP5uQ5U5F8G9uMqfiVb75MOPKY7qdYCZZZg=
+      file_glob: true
+      file: dist/*.*
+      skip-cleanup: true
+      on:
+        tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,17 @@ jobs:
     - docker run -d -p 5672:5672 rabbitmq:3
     script:
     - docker ps
-    - mvn -f $PARENT_POM -ntp install
-    deploy:
-      on:
-        all_branches: true
-      skip_cleanup: true
-      provider: script
-      script:
+    - mvn -f $PARENT_POM -ntp install    
+    after_script: # TODO: Only run this on tagged builds
       - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
+      # TMP
+      - find . -type f -name "*.zip"
+    # deploy:
+    #   provider: releases
+    #   api_key:
+    #     secure: DdirbOkYUePnKisYPlqYOpyti2HQFWmSIwY5spWflTUglzEZbnp+Q3sEltTebdlWo18i9skz6P5seAAXbX2ye1c3EZhqEyirWMxz1lvGdlNoQGHhWK6x+suM1DrG6Uun5dmcG/CEpWhDpcEbF8xQ/revtyCHEJj4xK9TXUHyFFG/KrzKSLGtsiBG1BOPkHJr4CoHjcpLzpmDB2hn+pYENtl3Nk0EeKmJgWdY/BWctEmUmRAXgfwsO/ejm9IbC5mIy5KBxbIUco/mf2JEKQB1drwdbINMxJXkbx+mWZYiDJBo5CWuWIzNOxv0Z3+Kg+N2cSwPX833v+W5YRTHyef/7Dum1yUrD3T7LMLY+3EIeCoGvARfRnQbi+BM9n1rFobPy/PWHWYxYRDnhDEfXrMcAyH/66InlQIhUh7XD01oZLEbsdZAbGnEsv5Ttz3F9LaEpk3EfoGqLxOWkL50OCxw6Jk6TfxsNtMoLpK1g7Jp8sI/EkjxYISer7S5myzLhKtgbtBwI0RcKh/sUo2m69QX++1JYy6CeN7/EwRmV4zJLk0WgalJuxgNFYrdzPLvg09okgxr1stHZQ7a5RkLH+r8KzA/Lmj6vTQG9HB44lHvX1hMiD0v8aCii+/wfr9AZZlNHjYq8RuHsP5uQ5U5F8G9uMqfiVb75MOPKY7qdYCZZZg=
+    #   file_glob: true
+    #   file: releasesolution/bin/*.*
+    #   skip-cleanup: true
+    #   on:
+    #     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
     after_success:
 #    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - |
-      for platform in linux windows
+      for platform in linux win
       do
         dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo
       done

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,17 +32,17 @@ jobs:
     script:
     - docker ps
     - dotnet build --verbosity quiet
-#    - dotnet test ./tests/common/Smi.Common.Tests/Smi.Common.Tests.csproj
-#    - dotnet test ./tests/common/Smi.Common.MongoDb.Tests/Smi.Common.MongoDb.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.CohortExtractor.Tests/Microservices.CohortExtractor.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.CohortPackager.Tests/Microservices.CohortPackager.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.DeadLetterReprocessor.Tests/Microservices.DeadLetterReprocessor.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.DicomRelationalMapper.Tests/Microservices.DicomRelationalMapper.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.DicomReprocessor.Tests/Microservices.DicomReprocessor.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.DicomTagReader.Tests/Microservices.DicomTagReader.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.IdentifierMapper.Tests/Microservices.IdentifierMapper.Tests.csproj
-#    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
-#    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
+    - dotnet test ./tests/common/Smi.Common.Tests/Smi.Common.Tests.csproj
+    - dotnet test ./tests/common/Smi.Common.MongoDb.Tests/Smi.Common.MongoDb.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.CohortExtractor.Tests/Microservices.CohortExtractor.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.CohortPackager.Tests/Microservices.CohortPackager.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.DeadLetterReprocessor.Tests/Microservices.DeadLetterReprocessor.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.DicomRelationalMapper.Tests/Microservices.DicomRelationalMapper.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.DicomReprocessor.Tests/Microservices.DicomReprocessor.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.DicomTagReader.Tests/Microservices.DicomTagReader.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.IdentifierMapper.Tests/Microservices.IdentifierMapper.Tests.csproj
+    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
+    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
     after_success:
     - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - |
@@ -50,10 +50,7 @@ jobs:
       do
         dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo
       done
-    - cd dist
-    - zip -r win-x64-$TRAVIS_TAG.zip ./win-x64
-    - tar czf linux-x64-$TRAVIS_TAG.tar.gz ./linux-x64
-    - cd ..
+    - ( cd dist && zip -r win-x64-$TRAVIS_TAG.zip ./win-x64 && tar czf linux-x64-$TRAVIS_TAG.tar.gz ./linux-x64 && cd - )
 
   - language: java
     env:
@@ -65,9 +62,7 @@ jobs:
     - export PATH=`pwd`/apache-maven-$MVN_VERSION/bin:$PATH
     - mvn -v
     install:
-    - cd ./lib/java
-    - ./installDat.sh
-    - cd ../..
+    - ( cd ./lib/java && ./installDat.sh && cd - )
     before_script:
     - docker run -d -p 5672:5672 rabbitmq:3
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
 #    - dotnet test ./tests/microservices/Microservices.IdentifierMapper.Tests/Microservices.IdentifierMapper.Tests.csproj
 #    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
 #    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
-    after_script:
+    after_success:
     - |
       for platform in linux windows
       do
@@ -79,7 +79,7 @@ jobs:
     script:
     - docker ps
     - mvn -f $PARENT_POM -ntp install    
-    after_script: # TODO: Only run this on tagged builds
+    after_success: # TODO: Only run this on tagged builds
       - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
       # TMP
       - find . -type f -name "*.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
       for filename in $(find ./src -name "*deploy-distribution.zip")
       do
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
-        mv --parents $filename dist/$base-${TRAVIS_TAG}.zip
+        mv $filename dist/$base-${TRAVIS_TAG}.zip
       done
     # TMP
     - ls -l ./dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 
 dist: bionic
 
-# Testing only!
-env:
-  - TRAVIS_TAG=test
-
-
 jobs:
   include:
   - language: csharp
@@ -49,6 +44,7 @@ jobs:
 #    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
 #    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
     after_success:
+    - export TRAVIS_TAG=test # Testing only!
     - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - |
       for platform in linux win
@@ -80,6 +76,7 @@ jobs:
     - docker ps
     - mvn -f $PARENT_POM -ntp install    
     after_success:
+    - export TRAVIS_TAG=test # Testing only!
     - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
     - |
@@ -92,6 +89,7 @@ jobs:
     - ls -l ./dist
     - du -sh ./dist/*
 
+# NOTE: This is inherited by both jobs, so actually runs twice
 deploy:
       provider: releases
       api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,11 +83,12 @@ jobs:
     after_success:
 #    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
+    - mkdir ./dist
     - |
       for filename in $(find ./src -name "*deploy-distribution.zip")
       do
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
-        mv --parents $filename dist/$base-${TRAVIS_TAG}.zip
+        mv $filename dist/$base-${TRAVIS_TAG}.zip
       done
     - ls ./dist
     # deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
       for filename in $(find ./src -name "*deploy-distribution.zip")
       do
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
-        mv $filename dist/$base-${TRAVIS_TAG}.zip
+        mv -p $filename dist/$base-${TRAVIS_TAG}.zip
       done
     - ls ./dist
     # deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
       for filename in $(find ./src -name "*deploy-distribution.zip")
       do
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
-        mv -p $filename dist/$base-${TRAVIS_TAG}.zip
+        mv --parents $filename dist/$base-${TRAVIS_TAG}.zip
       done
     - ls ./dist
     # deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ jobs:
     - export TRAVIS_TAG=test # Testing only!
     - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
+    - mkdir ./dist
     - |
       for filename in $(find ./src -name "*deploy-distribution.zip")
       do

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,9 @@ jobs:
 #    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
     - |
-      for filename in $(find ./src -name "*deploy-distribution.zip" -printf "%f\n")
+      for filename in $(find ./src -name "*deploy-distribution.zip")
       do
-        base=$(ls $filename | awk -F'-' '{print $1}')
+        base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
         mv $filename dist/$base-${TRAVIS_TAG}.zip
       done
     - ls ./dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
 #    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
 #    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
     after_success:
+#    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - |
       for platform in linux windows
       do
@@ -79,7 +80,8 @@ jobs:
     script:
     - docker ps
     - mvn -f $PARENT_POM -ntp install    
-    after_success: # TODO: Only run this on tagged builds
+    after_success:
+#    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
       - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
       # TMP
       - find . -type f -name "*.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
     mono: none
     dotnet: 2.2.100
     addons:
-      postgresql: '10'
+      postgresql: 10
       apt:
         packages:
         - postgresql-10
@@ -15,13 +15,13 @@ jobs:
     - mysql
     - mongodb
     before_install:
-    - docker run --name=mssql-server -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=YourStrong!Passw0rd'
-      -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest
+    - docker run --name=mssql-server -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=YourStrong!Passw0rd' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2017-latest
     - sudo apt install libc6-dev 
     - sudo apt install libgdiplus
-    - sleep 10
+    - sleep 10 # NOTE: This helps to ensure that the SQL server inside the Docker container has started
     install:
     - wget https://github.com/HicServices/RDMP/releases/download/v3.2.1/rdmp-cli-linux-x64.zip
+    # NOTE: unzip should run successfully, but returns a non-zero exit code since the zip was packaged from Windows using the '\' directory separator. We therefore need to ignore the exit code with "|| true"
     - unzip -d rdmp-cli rdmp-cli-linux-x64.zip || true
     - chmod +x rdmp-cli/rdmp
     - rdmp-cli/rdmp install localhost TEST_ -u sa -p 'YourStrong!Passw0rd'
@@ -69,7 +69,7 @@ jobs:
     - mvn -v
     install:
     - cd ./lib/java
-    - "./installDat.sh"
+    - ./installDat.sh
     - cd ../..
     before_script:
     - docker run -d -p 5672:5672 rabbitmq:3

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 #    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
 #    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
     after_success:
-#    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
+    - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - |
       for platform in linux win
       do
@@ -81,14 +81,13 @@ jobs:
     - docker ps
     - mvn -f $PARENT_POM -ntp install    
     after_success:
-#    - if [ -n "$TRAVIS_TAG" ]; then travis_terminate 0; fi
+    - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
-    - mkdir ./dist
     - |
       for filename in $(find ./src -name "*deploy-distribution.zip")
       do
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
-        mv $filename dist/$base-${TRAVIS_TAG}.zip
+        mv --parents $filename dist/$base-${TRAVIS_TAG}.zip
       done
     - ls ./dist
     # deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ jobs:
 #    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
 #    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
     after_success:
-    - export TRAVIS_TAG=test # Testing only!
     - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - |
       for platform in linux win
@@ -55,9 +54,6 @@ jobs:
     - zip -r win-x64-$TRAVIS_TAG.zip ./win-x64
     - tar czf linux-x64-$TRAVIS_TAG.tar.gz ./linux-x64
     - cd ..
-    # TMP
-    - ls -l ./dist/
-    - du -sh ./dist/*
 
   - language: java
     env:
@@ -78,7 +74,6 @@ jobs:
     - docker ps
     - mvn -f $PARENT_POM -ntp install    
     after_success:
-    - export TRAVIS_TAG=test # Testing only!
     - if [ -z "$TRAVIS_TAG" ]; then travis_terminate 0; fi
     - mvn -f $PARENT_POM -ntp assembly:single@create-deployable
     - mkdir ./dist
@@ -88,9 +83,6 @@ jobs:
         base=$(ls $filename | awk -F'-' '{print $1}' | awk -F'/' '{print $6}')
         mv $filename dist/$base-${TRAVIS_TAG}.zip
       done
-    # TMP
-    - ls -l ./dist
-    - du -sh ./dist/*
 
 # NOTE: This is inherited by both jobs, so actually runs twice
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
     - |
       for platform in linux win
       do
-        dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo
+        dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo -v q
       done
     - ( cd dist && zip -r win-x64-$TRAVIS_TAG.zip ./win-x64 && tar czf linux-x64-$TRAVIS_TAG.tar.gz ./linux-x64 && cd - )
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,25 +30,28 @@ jobs:
     script:
     - docker ps
     - dotnet build --verbosity quiet
-    - dotnet test ./tests/common/Smi.Common.Tests/Smi.Common.Tests.csproj
-    - dotnet test ./tests/common/Smi.Common.MongoDb.Tests/Smi.Common.MongoDb.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.CohortExtractor.Tests/Microservices.CohortExtractor.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.CohortPackager.Tests/Microservices.CohortPackager.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.DeadLetterReprocessor.Tests/Microservices.DeadLetterReprocessor.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.DicomRelationalMapper.Tests/Microservices.DicomRelationalMapper.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.DicomReprocessor.Tests/Microservices.DicomReprocessor.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.DicomTagReader.Tests/Microservices.DicomTagReader.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.IdentifierMapper.Tests/Microservices.IdentifierMapper.Tests.csproj
-    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
-    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
-    - dotnet publish ./releasesolution/SmiServicesRelease.sln -r win-x64 -c release
-      -o /home/travis/build/SMI/SmiServices/releasesolution/bin/win
-    - dotnet publish ./releasesolution/SmiServicesRelease.sln -r linux-x64 -c release
-      -o /home/travis/build/SMI/SmiServices/releasesolution/bin/linux
-    - tar -zcf ./releasesolution/bin/win-x64.zip ./releasesolution/bin/win
-    - tar -zcf ./releasesolution/bin/linux-x64.tar.gz ./releasesolution/bin/linux
-    - rm -rf ./releasesolution/bin/linux
-    - rm -rf ./releasesolution/bin/win
+#    - dotnet test ./tests/common/Smi.Common.Tests/Smi.Common.Tests.csproj
+#    - dotnet test ./tests/common/Smi.Common.MongoDb.Tests/Smi.Common.MongoDb.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.CohortExtractor.Tests/Microservices.CohortExtractor.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.CohortPackager.Tests/Microservices.CohortPackager.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.DeadLetterReprocessor.Tests/Microservices.DeadLetterReprocessor.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.DicomRelationalMapper.Tests/Microservices.DicomRelationalMapper.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.DicomReprocessor.Tests/Microservices.DicomReprocessor.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.DicomTagReader.Tests/Microservices.DicomTagReader.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.IdentifierMapper.Tests/Microservices.IdentifierMapper.Tests.csproj
+#    - dotnet test ./tests/microservices/Microservices.MongoDBPopulator.Tests/Microservices.MongoDBPopulator.Tests.csproj
+#    - dotnet test ./tests/applications/Applications.DicomDirectoryProcessor.Tests/Applications.DicomDirectoryProcessor.Tests.csproj
+    after_script:
+    - |
+      for platform in linux windows
+      do
+        dotnet publish -c Release -r $platform-x64 -o $(pwd)/dist/$platform-x64 --self-contained false -nologo
+      done
+    # - zip ./releasesolution/bin/win-x64.zip ./releasesolution/bin/win
+    # - tar -zcf ./releasesolution/bin/linux-x64.tar.gz ./releasesolution/bin/linux
+    # TMP
+    - ls -l ./dist/
+    - du -sh ./dist/*
     deploy:
       provider: releases
       api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Previously: `BasicReturn for TEST.IdentifiableImageExchange`
   - Now : `BasicReturn for Exchange 'TEST.IdentifiableImageExchange' Routing Key 'reprocessed' ReplyCode '312' (NO_ROUTE)`
 - Added new swapper `TableLookupWithGuidFallbackSwapper` which performs lookup substitutions but allocates guids for lookup misses
+- Added Travis CI build & deploy for all services
 
 ## [1.1.0] - 2019-11-22
 


### PR DESCRIPTION
Updates .travis.yml only:
- Added `<IsPublishable>false</>` to all test projects. This allows us to use a single sln file and publish command
- The building of distributable archives now only occurs for tagged builds which complete successfully
- Fixes the Windows zip archive actually being created as a tarball :)
- Moves deploy stage outside the job matrix so it runs for both
- Add some inline notes

Test release [0.0.0](https://github.com/SMI/SmiServices/releases/tag/0.0.0) was created with this. I've checked each archive and everything seems to look fine.

My only concern with all the services being dumped into the same output dir is when two services require separate versions of the same library. Whichever project is built later will clobber the existing  library dll. In the best case, this throws an exception immediately at runtime. In the worst case, this may cause a service to call a newer/older version of a library API which may cause unexpected behaviour.