### PR TITLE
Add Shutdown call to messaging consumers, defaulting to doing nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-...
+- Add clean shutdown hook for IdentifierMapper to clean up the worker threads
 
 ## [1.4.4] - 2020-02-25
 

--- a/src/common/Smi.Common/Messaging/Consumer.cs
+++ b/src/common/Smi.Common/Messaging/Consumer.cs
@@ -38,6 +38,10 @@ namespace Smi.Common.Messaging
 
         protected IModel Model;
 
+        public virtual void Shutdown()
+        {
+
+        }
 
         protected Consumer()
         {

--- a/src/common/Smi.Common/Messaging/IConsumer.cs
+++ b/src/common/Smi.Common/Messaging/IConsumer.cs
@@ -26,5 +26,10 @@ namespace Smi.Common.Messaging
         /// 
         /// </summary>
         event ConsumerFatalHandler OnFatal;
+
+        /// <summary>
+        /// Trigger a clean shutdown of worker threads etc
+        /// </summary>
+        void Shutdown();
     }
 }

--- a/src/common/Smi.Common/RabbitMQAdapter.cs
+++ b/src/common/Smi.Common/RabbitMQAdapter.cs
@@ -408,9 +408,9 @@ namespace Smi.Common
                 {
                     if (_threaded)
                     {
-                        worklock.EnterReadLock();
                         Task.Run(() =>
                         {
+                            worklock.EnterReadLock();
                             try
                             {
                                 consumer.ProcessMessage(e);

--- a/src/common/Smi.Common/RabbitMQAdapter.cs
+++ b/src/common/Smi.Common/RabbitMQAdapter.cs
@@ -434,6 +434,7 @@ namespace Smi.Common
                 // Now there are no *new* messages being processed, send a
                 // null one to flush the queue
                 consumer.Shutdown();
+                worklock.ExitWriteLock();
             }
             worklock.Dispose();
 

--- a/src/common/Smi.Common/RabbitMQAdapter.cs
+++ b/src/common/Smi.Common/RabbitMQAdapter.cs
@@ -433,7 +433,7 @@ namespace Smi.Common
 
                 // Now there are no *new* messages being processed, send a
                 // null one to flush the queue
-                consumer.ProcessMessage(null);
+                consumer.Shutdown();
             }
             worklock.Dispose();
 

--- a/src/common/Smi.Common/RabbitMQAdapter.cs
+++ b/src/common/Smi.Common/RabbitMQAdapter.cs
@@ -435,6 +435,7 @@ namespace Smi.Common
                 // null one to flush the queue
                 consumer.ProcessMessage(null);
             }
+            worklock.Dispose();
 
             string reason = "unknown";
 


### PR DESCRIPTION
Cleaner shutdown when asynchronous work is being done

## Proposed Changes

Added Shutdown method to Consumer
Call this from Rabbit adapter when shutting down in threaded mode
Use that to clean up and drain the Ack queue in IdentifierMapper

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [X] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [X] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [X] Updated any relevant API documentation
- [X] Created or updated any tests if relevant
- [X] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [X] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [X] Requested a review by one of the repository maintainers

## Issues

- Closes #131
