### PR TITLE
Feature/ctp routing key

### DIFF
--- a/src/microservices/Microservices.CohortExtractor/Execution/RequestFulfillers/FakeFulfiller.cs
+++ b/src/microservices/Microservices.CohortExtractor/Execution/RequestFulfillers/FakeFulfiller.cs
@@ -1,0 +1,46 @@
+
+using Microservices.CohortExtractor.Audit;
+using Smi.Common.Messages.Extraction;
+using NLog;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Microservices.CohortExtractor.Execution.RequestFulfillers
+{
+    public class FakeFulfiller : IExtractionRequestFulfiller
+    {
+        protected readonly Logger Logger;
+
+        public IRejector Rejector { get; set; } = new RejectNone();
+        public Regex ModalityRoutingRegex { get; set; }
+
+        public FakeFulfiller()
+        {
+            Logger = LogManager.GetCurrentClassLogger();
+
+            Logger.Debug("Faking a filename");
+        }
+
+        public IEnumerable<ExtractImageCollection> GetAllMatchingFiles(ExtractionRequestMessage message, IAuditExtractions auditor)
+        {
+            Logger.Debug("Found " + message.KeyTag);
+
+            foreach (string valueToLookup in message.ExtractionIdentifiers)
+            {
+                var results = new ExtractImageCollection(valueToLookup);
+                string filePathValue = "img001.dcm";
+                string studyTagValue = "2";
+                string seriesTagValue = "3";
+                string instanceTagValue = "4";
+                bool rejection = false;
+                string rejectionReason = "";
+                var result = new QueryToExecuteResult(filePathValue, studyTagValue, seriesTagValue, instanceTagValue, rejection, rejectionReason);
+                if(!results.ContainsKey(result.SeriesTagValue))
+                    results.Add(result.SeriesTagValue,new HashSet<QueryToExecuteResult>());
+                results[result.SeriesTagValue].Add(result);
+
+                yield return results;
+            }
+        }
+    }
+}

--- a/src/microservices/com.smi.microservices.ctpanonymiser/src/main/java/org/smi/ctpanonymiser/execution/CTPAnonymiserHost.java
+++ b/src/microservices/com.smi.microservices.ctpanonymiser/src/main/java/org/smi/ctpanonymiser/execution/CTPAnonymiserHost.java
@@ -63,12 +63,9 @@ public class CTPAnonymiserHost implements IMicroserviceHost {
 		// Build the SMI Anonymiser tool
 		SmiCtpProcessor anonTool = new DicomAnonymizerToolBuilder().tagAnonScriptFile(anonScriptFile).check(null).buildDat();
 
-		final String routingKey = "";
-
 		_consumer = new CTPAnonymiserConsumer(
 				_producer,
 				anonTool,
-				routingKey,
 				fsRoot,
 				exRoot);
 

--- a/src/microservices/com.smi.microservices.ctpanonymiser/src/test/java/org/smi/ctpanonymiser/test/execution/CTPAnonymiserHostTest.java
+++ b/src/microservices/com.smi.microservices.ctpanonymiser/src/test/java/org/smi/ctpanonymiser/test/execution/CTPAnonymiserHostTest.java
@@ -106,6 +106,8 @@ public class CTPAnonymiserHostTest extends TestCase {
 		_channel.exchangeDeclare(_producerExchangeName, "direct", true);
 		_channel.queueDeclare(_outputQueueName, true, false, false, null);
 		_channel.queueBind(_outputQueueName, _producerExchangeName, "");
+		_channel.queueBind(_outputQueueName, _producerExchangeName, "success");
+		_channel.queueBind(_outputQueueName, _producerExchangeName, "failure");
 		System.out.println(String.format("Bound %s -> %s", _producerExchangeName, _outputQueueName));
 
 		_channel.queuePurge(_consumerQueueName);

--- a/src/microservices/com.smi.microservices.ctpanonymiser/src/test/java/org/smi/ctpanonymiser/test/messages/ExtractFileMessageTest.java
+++ b/src/microservices/com.smi.microservices.ctpanonymiser/src/test/java/org/smi/ctpanonymiser/test/messages/ExtractFileMessageTest.java
@@ -47,7 +47,7 @@ public class ExtractFileMessageTest extends TestCase {
 	public void testSerializeDeserialize() {
 
 		ExtractFileMessage recvdMessage;
-		CTPAnonymiserConsumer consumer = new CTPAnonymiserConsumer(null, null, _routingKey, _fileSystemRoot, _extractFileSystemRoot);
+		CTPAnonymiserConsumer consumer = new CTPAnonymiserConsumer(null, null, _fileSystemRoot, _extractFileSystemRoot);
 
 		// Get byte array version of message
 		Gson _gson = new Gson();


### PR DESCRIPTION
## Proposed Changes

CTP should now pass on a routing key to indicate whether it succeeded or failed.
Had to remove routing_key from the constructor since it isn't used.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [X] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [ ] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [X] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [ ] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [ ] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [ ] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are *expected* to be resolved with this PR. E.g.:

- Closes #\<issue-number>
- ...
