### PR TITLE
BP: Modify pacs and list modes for path validation + add extra test c…

### DIFF
--- a/src/applications/Applications.DicomDirectoryProcessor/Execution/DicomDirectoryProcessorHost.cs
+++ b/src/applications/Applications.DicomDirectoryProcessor/Execution/DicomDirectoryProcessorHost.cs
@@ -29,8 +29,6 @@ namespace Applications.DicomDirectoryProcessor.Execution
 
             if (!cliOptions.DirectoryFormat.ToLower().Equals("list"))
             {
-                Logger.Info("This indicates that the list mode is not being recognised");
-
                 // TODO(rkm 2020-02-12) I think we want to check this regardless of the mode
                 // (bp 2020-02-13) By not doing this check on list means that the list of paths is not required to be in PACS and can be imported from anywhere
                 if (!Directory.Exists(globals.FileSystemOptions.FileSystemRoot))
@@ -44,7 +42,6 @@ namespace Applications.DicomDirectoryProcessor.Execution
             }
             else
             {
-                Logger.Info("This indicates that the list mode is being recognised");
                 if (!File.Exists(cliOptions.ToProcessDir.FullName))
                     throw new ArgumentException("Could not find accession directory list file (" + cliOptions.ToProcessDir.FullName + ")");
 

--- a/src/applications/Applications.DicomDirectoryProcessor/Execution/DirectoryFinders/AccessionDirectoryLister.cs
+++ b/src/applications/Applications.DicomDirectoryProcessor/Execution/DirectoryFinders/AccessionDirectoryLister.cs
@@ -12,7 +12,7 @@ namespace Applications.DicomDirectoryProcessor.Execution.DirectoryFinders
     public class AccessionDirectoryLister : DicomDirectoryFinder
     {
         // Regex that matches when we are at the yyyy\mm\dd\xxxxx directory level
-        private readonly Regex _accDirectoryRegex = new Regex(@"(20\d{2}[\\\/]\d{2}[\\\/]\d{2})[\\\/]\w+[^.]*?$");
+        private readonly Regex _accDirectoryRegex = new Regex(@"(20\d{2}[\\\/]\d{2}[\\\/]\d{2}[\\\/][a-zA-Z0-9._-]+[\\\/]$)");
 
         public AccessionDirectoryLister(string fileSystemRoot, IFileSystem fileSystem, string dicomSearchPattern, IProducerModel directoriesProducerModel)
         : base(fileSystemRoot, fileSystem, dicomSearchPattern, directoriesProducerModel) { }

--- a/src/applications/Applications.DicomDirectoryProcessor/Execution/DirectoryFinders/PacsDirectoryFinder.cs
+++ b/src/applications/Applications.DicomDirectoryProcessor/Execution/DirectoryFinders/PacsDirectoryFinder.cs
@@ -13,7 +13,7 @@ namespace Applications.DicomDirectoryProcessor.Execution.DirectoryFinders
         // Regex that matches when we are at the yyyy\mm\dd\ directory level
         private readonly Regex _dayDirectoryRegex = new Regex(@"(20\d{2}[\\\/]\d{2}[\\\/]\d{2})([\\\/]|$)");
         // Regex that matches when we are at the yyyy\mm\dd\xxxxx directory level
-        private readonly Regex _accDirectoryRegex = new Regex(@"(20\d{2}[\\\/]\d{2}[\\\/]\d{2})[\\\/]\w+[\\\/]?$");
+        private readonly Regex _accDirectoryRegex = new Regex(@"(20\d{2}[\\\/]\d{2}[\\\/]\d{2}[\\\/][a-zA-Z0-9._-]+[\\\/]$)");
 
 
         public PacsDirectoryFinder(string fileSystemRoot, IFileSystem fileSystem, string dicomSearchPattern, IProducerModel directoriesProducerModel)

--- a/tests/applications/Applications.DicomDirectoryProcessor.Tests/AccessionDirectoryListerTest.cs
+++ b/tests/applications/Applications.DicomDirectoryProcessor.Tests/AccessionDirectoryListerTest.cs
@@ -26,16 +26,15 @@ namespace Applications.DicomDirectoryProcessor.Tests
             TestLogger.Setup();
         }
         
-        // TODO(rkm 2020-02-12) Things to test
-        // - Valid CSV file
-        // - CSVs with various invalid data / lines
 	private String GetListContent()
 	{
             StringBuilder accessionList = new StringBuilder();
 
-	    accessionList.AppendLine("/PACS/2018/01/01/AAA,");           // exists and has dicom files - pass 
+	    accessionList.AppendLine("/PACS/2018/01/01/AAA,");           // exists and has dicom files - fail (requires indication that is dir) 
 	    accessionList.AppendLine("/PACS/2018/01/01/AAA/,");          // exists and has dicom files - pass
-	    accessionList.AppendLine("/PACS/2018/01/01/BBB,");           // does exist but has no dicom files - fail
+	    accessionList.AppendLine("/PACS/2018/01/01/E-123/,");        // exists and has dicom files - pass
+	    accessionList.AppendLine("/PACS/2018/01/01/01.01.2018/,");   // exists and has dicom files - pass
+	    accessionList.AppendLine("/PACS/2018/01/01/BBB/,");          // does exist but has no dicom files - fail
 	    accessionList.AppendLine("/PACS/2018/01/01/CCC/,");          // does not exist - fail
 	    accessionList.AppendLine("/PACS/2018/01/01/,");              // not pointing to accession directory - fail
 	    accessionList.AppendLine("/PACS/2018/01/01/testDicom.dcm,"); // not pointing to accession directory - fail
@@ -55,7 +54,13 @@ namespace Applications.DicomDirectoryProcessor.Tests
 
 	    string testDicom = Path.GetFullPath(Path.Combine(rootDir, "2018/01/01/AAA/test.dcm"));
 	    mockFilesystem.AddFile(testDicom, MockFileData.NullObject);
+	    
+	    string specialCase1 = Path.GetFullPath(Path.Combine(rootDir, "2018/01/01/E-123/test.dcm"));
+	    mockFilesystem.AddFile(specialCase1, MockFileData.NullObject);
 
+	    string specialCase2 = Path.GetFullPath(Path.Combine(rootDir, "2018/01/01/01.01.2018/test.dcm"));
+	    mockFilesystem.AddFile(specialCase2, MockFileData.NullObject);
+	    
 	    string testBad = Path.GetFullPath(Path.Combine(rootDir, "2018/01/01/BBB/test.txt"));
 	    mockFilesystem.AddFile(testBad, MockFileData.NullObject);
 	    
@@ -78,7 +83,7 @@ namespace Applications.DicomDirectoryProcessor.Tests
 
             accessionLister.SearchForDicomDirectories(accessionList);
 	    
-	    Assert.AreEqual(totalSent, 2);
+	    Assert.AreEqual(totalSent, 3);
         }
     }
 }

--- a/tests/applications/Applications.DicomDirectoryProcessor.Tests/PacsDirectoryFinderTests.cs
+++ b/tests/applications/Applications.DicomDirectoryProcessor.Tests/PacsDirectoryFinderTests.cs
@@ -24,21 +24,40 @@ namespace Applications.DicomDirectoryProcessor.Tests
         public void TestRegexMatches()
         {
             string rootDir = Path.GetFullPath("/PACS");
-            string testFile = Path.GetFullPath(Path.Combine(rootDir, "2018/01/01/AAA/testDicom.dcm"));
             var mockFs = new MockFileSystem();
+            
+	    string testFile = Path.GetFullPath(Path.Combine(rootDir, "2018/01/01/AAA/testDicom.dcm"));
             mockFs.AddFile(testFile, MockFileData.NullObject);
 
-            // Test case, expected messages
+	    string specialCase1 = Path.GetFullPath(Path.Combine(rootDir, "2016/01/01/E-12345/testDicom.dcm"));
+            mockFs.AddFile(specialCase1, MockFileData.NullObject);
+	    
+	    string specialCase2 = Path.GetFullPath(Path.Combine(rootDir, "2017/01/01/01.01.2017/testDicom.dcm"));
+            mockFs.AddFile(specialCase2, MockFileData.NullObject);
+	    
+	    string multiLayer1 = Path.GetFullPath(Path.Combine(rootDir, "2015/01/01/E-12345/testDicom.dcm"));
+            mockFs.AddFile(multiLayer1, MockFileData.NullObject);
+	    
+	    string multiLayer2 = Path.GetFullPath(Path.Combine(rootDir, "2015/01/01/AAA/testDicom.dcm"));
+            mockFs.AddFile(multiLayer2, MockFileData.NullObject);
+	    
+	    string multiLayer3 = Path.GetFullPath(Path.Combine(rootDir, "2015/01/01/BBB/testDicom.dcm"));
+            mockFs.AddFile(multiLayer3, MockFileData.NullObject);
+            
+	    // Test case, expected messages
             var testCases = new Dictionary<string, int>
             {
-                { "2018",               1 },
-                { "2018/",              1 },
-                { "2018/01",            1 },
-                { "2018/01/",           1 },
-                { "2018/01/01",         1 },
-                { "2018/01/01/",        1 },
-                { "2018/01/01/AAA",     1 },
-                { "2018/01/01/AAA/",    1 }
+                { "2018",                   1 },
+                { "2018/",                  1 },
+                { "2018/01",                1 },
+                { "2018/01/",               1 },
+                { "2018/01/01",             1 },
+                { "2018/01/01/",            1 },
+                { "2015/01/01/",            3 },
+                { "2018/01/01/AAA",         0 },
+                { "2018/01/01/AAA/",        1 },
+                { "2016/01/01/E-12345/",    1 },
+                { "2017/01/01/01.01.2017/", 1 }
             };
 
             var totalSent = 0;


### PR DESCRIPTION
## Proposed Changes

* Updated regex used for directory path validation causing special case accession directories such as `E-1234` and `01.01.2016` to be excluded. This has been applied to both pacs and list modes.
* Updated pacs and list tests to include special-case accession directories solved by updated regex

## Notes
If accession directory paths are being fed into the pacs or list modes, these need to indicate the fact that they are directories by ending in a (back/forward) slash. For list mode, these are automatically generated. For pacs mode, if entering an accession directory path without slash ending, it will be skipped.

It is recommended to use the list mode for accession directory paths instead of the pacs mode as it performs additional checks to ensure the validity of the accession directories.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues

N/A