### PR TITLE
Feature/reviewer improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Improved usability of IsIdentifiableReviewer
+
 ## [1.5.0] - 2020-03-05
 
 - \[Breaking\] Updated RabbitMQ extraction config to match extraction plan v2

--- a/src/applications/IsIdentifiableReviewer/IsIdentifiableReviewerOptions.cs
+++ b/src/applications/IsIdentifiableReviewer/IsIdentifiableReviewerOptions.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using IsIdentifiableReviewer.Out;
 
 namespace IsIdentifiableReviewer
 {
@@ -16,5 +17,27 @@ namespace IsIdentifiableReviewer
             HelpText = "[Optional] Runs the application automatically processing existing update/ignore rules.  Failures not matching either are written to a new file with this path"
         )]
         public string UnattendedOutputPath { get; set; }
+
+        [Option('t', "targets",
+            Required = false,
+            Default = "Targets.yaml",
+            HelpText = "Location of database connection strings file (for issuing UPDATE statements)"
+        )]
+        public string TargetsFile { get; set; }
+
+        [Option('i', "ignore",
+            Required = false,
+            Default = IgnoreRuleGenerator.DefaultFileName,
+            HelpText = "File containing rules for ignoring validation errors"
+        )]
+        public string IgnoreList { get; set; }
+        
+        [Option('r', "redlist",
+            Required = false,
+            Default = RowUpdater.DefaultFileName,
+            HelpText = "File containing rules for when to issue UPDATE statements"
+        )]
+        public string RedList { get; set; }
+
     }
 }

--- a/src/applications/IsIdentifiableReviewer/IsIdentifiableReviewerOptions.cs
+++ b/src/applications/IsIdentifiableReviewer/IsIdentifiableReviewerOptions.cs
@@ -39,5 +39,12 @@ namespace IsIdentifiableReviewer
         )]
         public string RedList { get; set; }
 
+
+        [Option('o', "only-rules",
+            Required = false,
+            Default = false,
+            HelpText = "Specify to make GUI UPDATE choices only create new rules instead of going to database"
+        )]
+        public bool OnlyRules { get; set; }
     }
 }

--- a/src/applications/IsIdentifiableReviewer/MainWindow.cs
+++ b/src/applications/IsIdentifiableReviewer/MainWindow.cs
@@ -116,7 +116,9 @@ namespace IsIdentifiableReviewer
             };
             frame.Add(cbCustomPattern);
 
-            var cbRulesOnly = new CheckBox(23,2,"Rules Only",false);
+            var cbRulesOnly = new CheckBox(23,2,"Rules Only",opts.OnlyRules);
+            Updater.RulesOnly = opts.OnlyRules;
+
             cbRulesOnly.Toggled += (c, s) => { Updater.RulesOnly = cbRulesOnly.Checked;};
             frame.Add(cbRulesOnly);
             
@@ -413,10 +415,10 @@ namespace IsIdentifiableReviewer
                     dlg.Add(text);
             }
 
-            var txt = new TextField(0, line++, DlgWidth,initialValue ?? "");
+            var txt = new TextField(0, line++, DlgWidth -4 ,initialValue ?? "");
             dlg.Add(txt);
 
-            var btn = new Button(0, line++, "Ok")
+            var btn = new Button(0, line, "Ok")
             {
                 IsDefault = true,
                 Clicked = () =>
@@ -425,9 +427,15 @@ namespace IsIdentifiableReviewer
                     optionChosen = true;
                 }
             };
-
-
             dlg.Add(btn);
+
+            var btnClear = new Button(15, line, "Clear")
+            {
+                Clicked = () => { txt.Text = ""; }
+            };
+            dlg.Add(btnClear);
+
+            
 
             dlg.FocusFirst();
         

--- a/src/applications/IsIdentifiableReviewer/MainWindow.cs
+++ b/src/applications/IsIdentifiableReviewer/MainWindow.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using IsIdentifiableReviewer.Out;
-using Microservices.IsIdentifiable.Rules;
 using Terminal.Gui;
 using Attribute = Terminal.Gui.Attribute;
 
@@ -18,9 +17,9 @@ namespace IsIdentifiableReviewer
         public Target CurrentTarget { get; set; }
         public ReportReader CurrentReport { get; set; }
 
-        public IgnoreRuleGenerator Ignorer { get; set; } = new IgnoreRuleGenerator();
+        public IgnoreRuleGenerator Ignorer { get; }
 
-        public RowUpdater Updater { get; set; } = new RowUpdater();
+        public RowUpdater Updater { get;  } 
 
         public int DlgWidth = 78;
         public int DlgHeight = 18;
@@ -29,9 +28,12 @@ namespace IsIdentifiableReviewer
         private Label _info;
         private TextField _gotoTextField;
 
-        public MainWindow(List<Target> targets, IsIdentifiableReviewerOptions opts)
+        public MainWindow(List<Target> targets, IsIdentifiableReviewerOptions opts, IgnoreRuleGenerator ignorer, RowUpdater updater)
         {
             _targets = targets;
+            Ignorer = ignorer;
+            Updater = updater;
+
             X = 0;
             Y = 1;
             Width = Dim.Fill();

--- a/src/applications/IsIdentifiableReviewer/Out/IRulePatternFactory.cs
+++ b/src/applications/IsIdentifiableReviewer/Out/IRulePatternFactory.cs
@@ -1,0 +1,14 @@
+﻿using Microservices.IsIdentifiable.Reporting;
+
+namespace IsIdentifiableReviewer.Out
+{
+    public interface IRulePatternFactory
+    {
+        /// <summary>
+        /// Returns a Regex for picking up the provided <paramref name="failure"/>
+        /// </summary>
+        /// <param name="failure"></param>
+        /// <returns></returns>
+        string GetPattern(Failure failure);
+    }
+}

--- a/src/applications/IsIdentifiableReviewer/Out/MatchWholeStringRulePatternFactory.cs
+++ b/src/applications/IsIdentifiableReviewer/Out/MatchWholeStringRulePatternFactory.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.RegularExpressions;
+using Microservices.IsIdentifiable.Reporting;
+
+namespace IsIdentifiableReviewer.Out
+{
+    public class MatchWholeStringRulePatternFactory: IRulePatternFactory
+    {
+        public string GetPattern(Failure failure)
+        {
+            return "^" + Regex.Escape(failure.ProblemValue) + "$";
+        }
+    }
+}

--- a/src/applications/IsIdentifiableReviewer/Out/OutBase.cs
+++ b/src/applications/IsIdentifiableReviewer/Out/OutBase.cs
@@ -14,6 +14,8 @@ namespace IsIdentifiableReviewer.Out
     {
         protected List<IsIdentifiableRule> Rules { get;}
         public FileInfo RulesFile { get; }
+        
+        public IRulePatternFactory RulesFactory { get; set; } = new MatchWholeStringRulePatternFactory();
 
         protected OutBase(FileInfo rulesFile)
         {
@@ -53,7 +55,7 @@ namespace IsIdentifiableReviewer.Out
             {
                 Action = action,
                 IfColumn = f.ProblemField,
-                IfPattern = "^" + Regex.Escape(f.ProblemValue) + "$",
+                IfPattern = RulesFactory.GetPattern(f),
                 As = 
                     action == RuleAction.Ignore? 
                         FailureClassification.None : 

--- a/src/applications/IsIdentifiableReviewer/Out/RowUpdater.cs
+++ b/src/applications/IsIdentifiableReviewer/Out/RowUpdater.cs
@@ -30,15 +30,16 @@ namespace IsIdentifiableReviewer.Out
         {
         }
 
-        public void Update(Target target, Failure failure)
+        public void Update(Target target, Failure failure, bool addRule)
         {
-            Update(target.Discover(),failure);
+            Update(target.Discover(),failure,addRule);
         }
 
-        public void Update(DiscoveredServer server, Failure failure)
+        public void Update(DiscoveredServer server, Failure failure, bool addRule)
         {
             //add the update rule to the redlist
-            Add(failure,RuleAction.Report);
+            if(addRule)
+                Add(failure,RuleAction.Report);
 
             //if we are running in rules only mode we don't need to also update the database
             if(RulesOnly)
@@ -104,7 +105,7 @@ namespace IsIdentifiableReviewer.Out
             if (IsCoveredByExistingRule(failure))
             {
                 //since user has issued an update for this exact problem before we can update this one too
-                Update(server,failure);
+                Update(server,failure,false);
 
                 //and return false to indicate that it is not a novel issue
                 return false;

--- a/src/applications/IsIdentifiableReviewer/Program.cs
+++ b/src/applications/IsIdentifiableReviewer/Program.cs
@@ -42,7 +42,7 @@ namespace IsIdentifiableReviewer
             {
                 var file = new FileInfo(opts.TargetsFile);
 
-                if (file.Exists)
+                if (!file.Exists)
                 {
                     Console.Write($"Could not find '{file.FullName}'");
                     returnCode = -1;
@@ -66,7 +66,7 @@ namespace IsIdentifiableReviewer
                 return;
             }
 
-            Console.Write("Running Connection Tests");
+            Console.WriteLine("Running Connection Tests");
 
             foreach (Target t in targets)
                 Console.WriteLine(t.Discover().Exists()
@@ -90,6 +90,9 @@ namespace IsIdentifiableReviewer
                 }
                 else
                 {
+                    Console.WriteLine("Press any key to launch GUI");
+                    Console.ReadKey();
+
                     //run interactive
                     Application.Init();
                     var mainWindow = new MainWindow(targets,opts,ignorer,updater);

--- a/src/applications/IsIdentifiableReviewer/Program.cs
+++ b/src/applications/IsIdentifiableReviewer/Program.cs
@@ -51,7 +51,14 @@ namespace IsIdentifiableReviewer
                 returnCode = -1;
                 return;
             }
-            
+
+            Console.Write("Running Connection Tests");
+
+            foreach (Target t in targets)
+                Console.WriteLine(t.Discover().Exists()
+                    ? $"Successfully connected to {t.Name}"
+                    : $"Failed to connect to {t.Name}");
+
             try
             {
                 if(!string.IsNullOrWhiteSpace(opts.UnattendedOutputPath))

--- a/src/applications/IsIdentifiableReviewer/UnattendedReviewer.cs
+++ b/src/applications/IsIdentifiableReviewer/UnattendedReviewer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using IsIdentifiableReviewer.Out;
 using Microservices.IsIdentifiable.Options;
@@ -48,6 +49,9 @@ namespace IsIdentifiableReviewer
             
             var storeReport = new FailureStoreReport(_outputFile.Name,100);
             
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
             using (var storeReportDestination = new CsvDestination(new IsIdentifiableDicomFileOptions(), _outputFile))
             {
                 storeReport.AddDestination(storeReportDestination);
@@ -70,8 +74,11 @@ namespace IsIdentifiableReviewer
 
                     Total++;
 
-                    if(Total% 10000 == 0)
+                    if (Total % 10000 == 0 || sw.ElapsedMilliseconds > 5000)
+                    {
                         Console.WriteLine($"Done {Total:N0} u={Updates:N0} i={Ignores:N0} o={Unresolved:N0}");
+                        sw.Restart();
+                    }
                 }
 
                 storeReport.CloseReport();

--- a/src/applications/IsIdentifiableReviewer/UnattendedReviewer.cs
+++ b/src/applications/IsIdentifiableReviewer/UnattendedReviewer.cs
@@ -21,7 +21,7 @@ namespace IsIdentifiableReviewer
         public int Unresolved = 0;
         public int Total = 0;
 
-        public UnattendedReviewer(IsIdentifiableReviewerOptions opts, Target target)
+        public UnattendedReviewer(IsIdentifiableReviewerOptions opts, Target target, IgnoreRuleGenerator ignorer, RowUpdater updater)
         {
             if (string.IsNullOrWhiteSpace(opts.FailuresCsv))
                 throw new Exception("Unattended requires a file of errors to process");
@@ -39,8 +39,8 @@ namespace IsIdentifiableReviewer
 
             _outputFile = new FileInfo(opts.UnattendedOutputPath);
 
-            _updater = new RowUpdater();
-            _ignorer = new IgnoreRuleGenerator();
+            _ignorer = ignorer;
+            _updater = updater;
         }
 
         public int Run()

--- a/src/microservices/Microservices.IsIdentifiable/Runners/DicomFileRunner.cs
+++ b/src/microservices/Microservices.IsIdentifiable/Runners/DicomFileRunner.cs
@@ -242,15 +242,15 @@ namespace Microservices.IsIdentifiable.Runners
             }
             catch (Exception e)
             {
-                // XXX ideally we should return an error code indicating unable to verify
-                // XXX instead we add a message to the report saying we failed to run OCR
+                // An internal error should cause IsIdentifiable to exit
                 _logger.Info(e, "Could not run Tesseract on '" + fi.FullName + "'");
-                //throw new Exception ("Could not run Tesseract on '" + fi.FullName + "'", e);
+                throw new Exception ("Could not run Tesseract on '" + fi.FullName + "'", e);
 
-                string problemField = "PixelData";
-                string text = "Error running OCR on pixel data: "+e;
-                var f = factory.Create(fi, dicomFile, text, problemField, new[] { new FailurePart(text, FailureClassification.PixelText) });
-                AddToReports(f);
+                // OR add a message to the report saying we failed to run OCR
+                //string problemField = "PixelData";
+                //string text = "Error running OCR on pixel data: "+e;
+                //var f = factory.Create(fi, dicomFile, text, problemField, new[] { new FailurePart(text, FailureClassification.PixelText) });
+                //AddToReports(f);
                 // XXX do we need this?
                 //_tesseractReport.FoundPixelData(fi, sopID, pixelFormat, processedPixelFormat, studyID, seriesID, modality, imageType, meanConfidence, text.Length, text, rotationIfAny);
             }

--- a/tests/microservices/Microservices.IsIdentifiable.Tests/ReviewerTests/TestUpdater.cs
+++ b/tests/microservices/Microservices.IsIdentifiable.Tests/ReviewerTests/TestUpdater.cs
@@ -57,7 +57,7 @@ namespace Microservices.IsIdentifiable.Tests.ReviewerTests
             //it should be novel i.e. require user decision
             Assert.IsTrue(updater.OnLoad(db.Server,failure));
 
-            updater.Update(db.Server,failure);
+            updater.Update(db.Server,failure,true);
 
             var result = tbl.GetDataTable();
             Assert.AreEqual("We aren't in SMI_REDACTED anymore SMI_REDACTED",result.Rows[0]["Narrative"]);

--- a/tests/microservices/Microservices.IsIdentifiable.Tests/ReviewerTests/UnattendedTests.cs
+++ b/tests/microservices/Microservices.IsIdentifiable.Tests/ReviewerTests/UnattendedTests.cs
@@ -17,7 +17,7 @@ namespace Microservices.IsIdentifiable.Tests.ReviewerTests
         public void NoFileToProcess_Throws()
         {
 
-            var ex = Assert.Throws<Exception>(() => new UnattendedReviewer(new IsIdentifiableReviewerOptions(),null));
+            var ex = Assert.Throws<Exception>(() => new UnattendedReviewer(new IsIdentifiableReviewerOptions(),null, new IgnoreRuleGenerator(),new RowUpdater() ));
             Assert.AreEqual("Unattended requires a file of errors to process",ex.Message);
         }
 
@@ -28,7 +28,7 @@ namespace Microservices.IsIdentifiable.Tests.ReviewerTests
             var ex = Assert.Throws<FileNotFoundException>(() => new UnattendedReviewer(new IsIdentifiableReviewerOptions()
             {
                 FailuresCsv = "troll.csv"
-            },null));
+            },null, new IgnoreRuleGenerator(),new RowUpdater()));
             StringAssert.Contains("Could not find Failures file",ex.Message);
         }
         
@@ -42,7 +42,7 @@ namespace Microservices.IsIdentifiable.Tests.ReviewerTests
             var ex = Assert.Throws<Exception>(() => new UnattendedReviewer(new IsIdentifiableReviewerOptions()
             {
                 FailuresCsv = fi
-            },null));
+            },null, new IgnoreRuleGenerator(),new RowUpdater()));
             StringAssert.Contains("A single Target must be supplied for database updates",ex.Message);
         }
 
@@ -55,7 +55,7 @@ namespace Microservices.IsIdentifiable.Tests.ReviewerTests
             var ex = Assert.Throws<Exception>(() => new UnattendedReviewer(new IsIdentifiableReviewerOptions()
             {
                 FailuresCsv = fi
-            },new Target()));
+            },new Target(), new IgnoreRuleGenerator(),new RowUpdater()));
             StringAssert.Contains("An output path must be specified ",ex.Message);
         }
 
@@ -75,7 +75,7 @@ namespace Microservices.IsIdentifiable.Tests.ReviewerTests
             {
                 FailuresCsv = fi,
                 UnattendedOutputPath = fiOut
-            }, new Target());
+            }, new Target(), new IgnoreRuleGenerator(),new RowUpdater());
 
             Assert.AreEqual(0,reviewer.Run());
             
@@ -111,7 +111,7 @@ FunBooks.HappyOzz,1.2.3,Narrative,We aren't in Kansas anymore Toto,Kansas###Toto
             {
                 FailuresCsv = fi,
                 UnattendedOutputPath = fiOut
-            }, new Target());
+            }, new Target(), new IgnoreRuleGenerator(),new RowUpdater());
 
             Assert.AreEqual(0,reviewer.Run());
             
@@ -159,7 +159,7 @@ FunBooks.HappyOzz,1.2.3,Narrative,We aren't in Kansas anymore Toto,Kansas###Toto
             {
                 FailuresCsv = fi,
                 UnattendedOutputPath = fiOut
-            }, new Target());
+            }, new Target(), new IgnoreRuleGenerator(),new RowUpdater());
 
             Assert.AreEqual(0,reviewer.Run());
             


### PR DESCRIPTION
## Proposed Changes

- Fix errors on startup e.g. due to bad yaml or connection strings (these currently freeze up the console - until you type 'reset')
- Allow Targets.yaml to be injected from CLI (shouldn't have to sit in the current directory of the binary)
- Allow Redlist / IgnoreList to be injected from CLI (so we can maintain a master copy )
- Add new checkbox for custom Regex patterns for Update/Ignore
- Allow the 'rules only' option (i.e. don't udpate the database) to be injected from CLI
- Better database connection string testing

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are *expected* to be resolved with this PR. E.g.:

- Closes #\<issue-number>
- ...
