### PR TITLE
Have Appveyor ignore PR builds to reduce duplication (Travis builds b…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,16 @@ services:
   - mysql
   - postgresql101
   - mongodb
-  
+ 
+skip_commits:
+  files:
+    - '**/*.md'
+
+cache:
+  - '%USERPROFILE%\.nuget\packages -> **\*.csproj'
+
 before_build:
-- cmd: if not defined COVERALLS_REPO_TOKEN appveyor exit
+- cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER appveyor exit
 - choco install opencover.portable
 - choco install rabbitmq
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ services:
   - mongodb
   
 before_build:
+- cmd: if not defined COVERALLS_REPO_TOKEN appveyor exit
 - choco install opencover.portable
 - choco install rabbitmq
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ cache:
   - '%USERPROFILE%\.nuget\packages -> **\*.csproj'
 
 before_build:
-- cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER appveyor exit
+- cmd: if defined APPVEYOR_PULL_REQUEST_NUMBER appveyor exit
 - choco install opencover.portable
 - choco install rabbitmq
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ services:
   - postgresql101
   - mongodb
  
-skip_commits:
-  files:
-    - '**/*.md'
-
 cache:
   - '%USERPROFILE%\.nuget\packages -> **\*.csproj'
 


### PR DESCRIPTION
Have Appveyor ignore PR builds to reduce duplication (Travis builds both anyway, Appveyor is being used to generate coverage reports, which doesn't work on PRs anyway)