### PR TITLE
Bugfix - cohort packager newline parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed a bug where newlines would never be correctly parsed from the config option in CohortPackager
+
 ### Dependencies
 
 - Bump System.IO.Abstractions.TestingHelpers from 13.2.2 to 13.2.4

--- a/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
+++ b/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
@@ -55,7 +55,7 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
 
             _csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                NewLine = ParseToCsvNewLine(ReportNewLine),
+                NewLine = ParseToCsvNewLine(Regex.Escape(ReportNewLine)),
             };
         }
 
@@ -459,7 +459,7 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
         }
 
         // NOTE(rkm 2020-12-10) The NewLine class only exists in the CsvHelper lib, so can't really use throughout the sln. As far as I
-        // can tell, this is the most straightforward way to parse a "NewLine" from an input string
+        // can tell, this is the most straightforward way to parse a "NewLine" from an input string. The input string must already be escaped.
         private static NewLine ParseToCsvNewLine(string newLine) =>
             newLine switch
             {

--- a/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
+++ b/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 
 namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
@@ -48,7 +49,7 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
             }
             else
             {
-                Logger.Warn($"Not passed a specific newline string for creating reports. Defaulting to Environment.NewLine ({Environment.NewLine})");
+                Logger.Warn($"Not passed a specific newline string for creating reports. Defaulting to Environment.NewLine ('{Regex.Escape(Environment.NewLine)}')");
                 ReportNewLine = Environment.NewLine;
             }
 
@@ -465,7 +466,7 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
                 @"\r" => NewLine.CR,
                 @"\r\n" => NewLine.CRLF,
                 @"\n" => NewLine.LF,
-                _ => throw new ArgumentException($"No case for '{newLine}'")
+                _ => throw new ArgumentException($"No case for '{Regex.Escape(newLine)}'")
             };
 
         protected abstract void ReleaseUnmanagedResources();

--- a/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
+++ b/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
@@ -457,14 +457,14 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
             sb.Append(ReportNewLine);
         }
 
-        // NOTE(rkm 2020-11-20) The NewLine class only exists in the CsvHelper lib, so can't really use throughout the sln. As far as I
-        // can tell, this is the most straightforward way to parse a "NewLine" from one of the "NewLines" string constants they provide...
+        // NOTE(rkm 2020-12-10) The NewLine class only exists in the CsvHelper lib, so can't really use throughout the sln. As far as I
+        // can tell, this is the most straightforward way to parse a "NewLine" from an input string
         private static NewLine ParseToCsvNewLine(string newLine) =>
             newLine switch
             {
-                NewLines.CR => NewLine.CR,
-                NewLines.CRLF => NewLine.CRLF,
-                NewLines.LF => NewLine.LF,
+                @"\r" => NewLine.CR,
+                @"\r\n" => NewLine.CRLF,
+                @"\n" => NewLine.LF,
                 _ => throw new ArgumentException($"No case for '{newLine}'")
             };
 


### PR DESCRIPTION
## Proposed Changes

Fixed a bug where newlines would never be correctly parsed from the config option in CohortPackager

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are *expected* to be resolved with this PR. E.g.:

-