### PR TITLE
Fixup newline parsing in CohortPackager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
--
+### Fixed
+
+-   [#581](https://github.com/SMI/SmiServices/pull/581) Fixed a bug where newlines would never be correctly parsed from the config option in CohortPackager
 
 ## [1.14.1] - 2021-02-04
+
+### Fixed
 
 -   [#576](https://github.com/SMI/SmiServices/pull/576) Fixup Windows package build
 
@@ -34,7 +38,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   Fixed a bug where newlines would never be correctly parsed from the config option in CohortPackager
 -   CohortPackager: Don't try and create the jobId file when recreating an existing report
 -   CohortPackager.Tests: Fix a flaky test caused by NUnit setup/teardown code when running tests in parallel
 -   CohortPackager.Tests: Fix a flaky test caused by using the same MongoDB database name when running tests in parallel

--- a/src/common/Smi.Common/Options/GlobalOptions.cs
+++ b/src/common/Smi.Common/Options/GlobalOptions.cs
@@ -312,6 +312,11 @@ namespace Smi.Common.Options
         public string ReporterType { get; set; }
         public string NotifierType { get; set; }
         public string ReportFormat { get; set; }
+
+        /// <summary>
+        /// The newline to use when writing extraction report files. Note that a "\r\n" string
+        /// in the YAML config will bee automatically escaped to "\\r\\n" in this string.
+        /// </summary>
         public string ReportNewLine { get; set; }
 
         public override string ToString()

--- a/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
+++ b/src/microservices/Microservices.CohortPackager/Execution/JobProcessing/Reporting/JobReporterBase.cs
@@ -50,12 +50,12 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
             else
             {
                 Logger.Warn($"Not passed a specific newline string for creating reports. Defaulting to Environment.NewLine ('{Regex.Escape(Environment.NewLine)}')");
-                ReportNewLine = Environment.NewLine;
+                ReportNewLine = Regex.Escape(Environment.NewLine);
             }
 
             _csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                NewLine = ParseToCsvNewLine(Regex.Escape(ReportNewLine)),
+                NewLine = ReportNewLine,
             };
         }
 
@@ -458,19 +458,6 @@ namespace Microservices.CohortPackager.Execution.JobProcessing.Reporting
             streamWriter.WriteLine();
             sb.Append(ReportNewLine);
         }
-
-        // NOTE(rkm 2020-12-10) The NewLine class only exists in the CsvHelper lib, so can't really use throughout the sln. As far as I
-        // can tell, this is the most straightforward way to parse a "NewLine" from an input string. The input string must already be escaped.
-        // NOTE(jas 2021-01-18) CsvHelper has changed to a strange hack. Any single char = use that for newline; null = use \r\n instead.
-        // NOTE(jas 2021-01-19) CsvHelper has switched to using plain strings. Much more sensible. Above notes now historical.
-        private static string ParseToCsvNewLine(string newLine) =>
-            newLine switch
-            {
-                @"\r" => "\r",
-                @"\r\n" => "\r\n",
-                @"\n" => "\n",
-                _ => throw new ArgumentException($"No case for '{Regex.Escape(newLine)}'")
-            };
 
         protected abstract void ReleaseUnmanagedResources();
         public abstract void Dispose();


### PR DESCRIPTION
## Proposed Changes

Fixes a bug where newlines would never be correctly parsed from the config option in CohortPackager.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
-