### PR TITLE
replace legacy SecurityCodeScan package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ Each entry in the changelog should use the following template:
 ```
 
 ## [Unreleased]
+
 ### Added
 
 - IsIdentifiableReviewer shows progress when loading large files (with cancellation support)
 - IsIdentifiableReviewer groups outstanding failures by column
 - [#616](https://github.com/SMI/SmiServices/pull/616) by `rkm`. Check for clobbered files during package build
+
+### Changed
+
+-   [#620](https://github.com/SMI/SmiServices/pull/620) by `rkm`. Replace the legacy SecurityCodeScan with SecurityCodeScan.VS2019.
 
 ### Fixed
 

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -23,7 +23,7 @@
 | NLog | [GitHub](https://github.com/NLog/NLog) | [BSD 3-Clause](https://github.com/NLog/NLog/blob/dev/LICENSE.txt) | Flexible user configurable logging |
 | Newtonsoft.Json | [GitHub](https://github.com/JamesNK/Newtonsoft.Json) | [MIT](https://opensource.org/licenses/MIT) | Serialization of objects for sharing/transmission
 | RabbitMQ.Client | [GitHub](https://github.com/rabbitmq/rabbitmq-dotnet-client) | [Apache License v2 / MPL 1.1](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/master/LICENSE) | Handles messaging between microservices |
-| SecurityCodeScan | [GitHub](https://security-code-scan.github.io/) | [LGPL 3.0](https://opensource.org/licenses/lgpl-3.0.html) | Scans code for security issues during build |
+| SecurityCodeScan.VS2019 | [GitHub](https://security-code-scan.github.io/) | [LGPL 3.0](https://opensource.org/licenses/lgpl-3.0.html) | Scans code for security issues during build |
 | StackExchange.Redis | [GitHub](https://github.com/StackExchange/StackExchange.Redis) |[MIT](https://opensource.org/licenses/MIT) | Required for RedisSwapper |
 | Stanford.NLP.CoreNLP | [GitHub Pages](https://sergey-tihon.github.io/Stanford.NLP.NET/) | [GNU v2](https://github.com/sergey-tihon/Stanford.NLP.NET/blob/master/LICENSE.txt)| Name / Organisation detection in text |
 | System.Drawing.Common | [GitHub](https://github.com/dotnet/corefx) | [MIT](https://opensource.org/licenses/MIT)  | Supports reading pixel data |

--- a/src/common/Smi.Common/Smi.Common.csproj
+++ b/src/common/Smi.Common/Smi.Common.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
-    <PackageReference Include="SecurityCodeScan" Version="3.5.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions" Version="13.2.15" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />


### PR DESCRIPTION
## Proposed Changes

Package is marked as legacy on Nuget.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Accurately updated the [CHANGELOG](https://github.com/SMI/SmiServices/blob/master/CHANGELOG.md)
  - NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
-