### PR TITLE
remove dotnet 2.2 runtime from CI builds

### DIFF
--- a/.azure-pipelines/jobs/tests.tmpl.yml
+++ b/.azure-pipelines/jobs/tests.tmpl.yml
@@ -53,12 +53,6 @@ jobs:
                 - template: ../steps/linux-dotnet-docker.yml
           - ${{ if eq( parameters.os, 'win' ) }}:
                 - template: ../steps/win-dotnet-services.yml
-          - task: UseDotNet@2
-            displayName: Use .NET Core Runtime 2.2 for RDMP
-            inputs:
-                packageType: runtime
-                version: 2.2.x
-                installationPath: $(Agent.ToolsDirectory)/dotnet
           - template: ../steps/rdmp-setup.tmpl.yml
             parameters:
                 os: ${{ parameters.os }}

--- a/news/736-meta.md
+++ b/news/736-meta.md
@@ -1,0 +1,1 @@
+Remove .NET Core 2.2 runtime from the Azure Pipelines builds


### PR DESCRIPTION
## Proposed Changes

Removes the unused dotnet 2.2 runtime.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
