### PR TITLE
Fix ordering of annotations in ExtractImagesCliOptions

### DIFF
--- a/news/737-bugfix.md
+++ b/news/737-bugfix.md
@@ -1,0 +1,1 @@
+Switch ordering of annotations in ExtractImagesCliOption to fix a runtime exception.

--- a/src/applications/Applications.ExtractImages/ExtractImagesCliOptions.cs
+++ b/src/applications/Applications.ExtractImages/ExtractImagesCliOptions.cs
@@ -46,9 +46,9 @@ namespace Applications.ExtractImages
         public bool NonInteractive { get; set; }
 
 
-        [ExcludeFromCodeCoverage]
         [UsedImplicitly]
         [Usage]
+        [ExcludeFromCodeCoverage]
         public static IEnumerable<Example> Examples
         {
             get


### PR DESCRIPTION
## Proposed Changes

Previous ordering causes an exception at runtime:

```console
Unhandled exception. System.InvalidCastException: Unable to cast object of type 'System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute' to type 'CommandLine.Text.UsageAttribute'.
```

Fix verified manually.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [ ] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
