### PR TITLE
Reviewer performance

### DIFF
--- a/news/754-feature.md
+++ b/news/754-feature.md
@@ -1,0 +1,1 @@
+Added parallelisation to load process in IsIdentifiableReviewer rules view

--- a/src/applications/Applications.IsIdentifiableReviewer/Views/OutstandingFailureNode.cs
+++ b/src/applications/Applications.IsIdentifiableReviewer/Views/OutstandingFailureNode.cs
@@ -15,7 +15,7 @@ namespace IsIdentifiableReviewer.Views
         /// <summary>
         /// Number of times the <see cref="FailurePart.Word"/> was seen in the report being evaluated
         /// </summary>
-        public int NumberOfTimesReported { get; set;}
+        public int NumberOfTimesReported;
 
         public OutstandingFailureNode(Failure failure, int numberOfTimesReported)
         {

--- a/src/applications/Applications.IsIdentifiableReviewer/Views/RulesView.cs
+++ b/src/applications/Applications.IsIdentifiableReviewer/Views/RulesView.cs
@@ -3,6 +3,7 @@ using Microservices.IsIdentifiable.Failures;
 using Microservices.IsIdentifiable.Reporting;
 using Microservices.IsIdentifiable.Rules;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -352,52 +353,66 @@ namespace IsIdentifiableReviewer.Views
         
         private void EvaluateRuleCoverageAsync(Label stage,ProgressBar progress, Label textProgress, CancellationToken token,TreeNodeWithCount colliding,TreeNodeWithCount ignore,TreeNodeWithCount update,TreeNodeWithCount outstanding)
         {
-            Dictionary<IsIdentifiableRule,int> rulesUsed = new Dictionary<IsIdentifiableRule, int>();
-            Dictionary<string,OutstandingFailureNode> outstandingFailures = new Dictionary<string, OutstandingFailureNode>();
+            ConcurrentDictionary<IsIdentifiableRule,int> rulesUsed = new ConcurrentDictionary<IsIdentifiableRule, int>();
+            ConcurrentDictionary<string,OutstandingFailureNode> outstandingFailures = new ConcurrentDictionary<string, OutstandingFailureNode>();
             
             int done = 0;
             var max = CurrentReport.Failures.Count();
+            object lockObj = new object();
 
-            foreach(Failure f in CurrentReport.Failures)
-            {
-                done++;
-                token.ThrowIfCancellationRequested();
-                if(done % 1000 == 0)
-                    SetProgress(progress,textProgress,done,max);
 
-                var ignoreRule = Ignorer.Rules.FirstOrDefault(r=>r.Apply(f.ProblemField,f.ProblemValue, out _) != RuleAction.None);
-                var updateRule = Updater.Rules.FirstOrDefault(r=>r.Apply(f.ProblemField,f.ProblemValue, out _) != RuleAction.None);
-
-                // record how often each reviewer rule was used with a failure
-                foreach(var r in new []{ ignoreRule,updateRule})
-                    if(r != null)
-                        if(!rulesUsed.ContainsKey(r))
-                            rulesUsed.Add(r,1);
-                        else
-                            rulesUsed[r]++;
-
-                // There are 2 conflicting rules for this input value (it should be updated and ignored!)
-                if(ignoreRule != null && updateRule != null)
+            var result = Parallel.ForEach(CurrentReport.Failures,
+                (f) =>
                 {
-                    // find an existing collision audit node for this input value
-                    var existing = colliding.Children.OfType<CollidingRulesNode>().FirstOrDefault(c=>c.CollideOn[0].ProblemValue.Equals(f.ProblemValue));
+                    token.ThrowIfCancellationRequested();
 
-                    if(existing != null)
-                        existing.Add(f);
-                    else
-                        colliding.Children.Add(new CollidingRulesNode(ignoreRule,updateRule,f));
-                }
+                    if (Interlocked.Increment(ref done) % 10000 == 0)
+                        SetProgress(progress, textProgress, done, max);
 
-                // input value that doesn't match any system rules yet
-                if(ignoreRule == null && updateRule == null)
-                {
-                    if(!outstandingFailures.ContainsKey(f.ProblemValue))
-                        outstandingFailures.Add(f.ProblemValue,new OutstandingFailureNode(f,1));
-                    else
-                        outstandingFailures[f.ProblemValue].NumberOfTimesReported++;
-                }
-            }
-            
+                    var ignoreRule = Ignorer.Rules.FirstOrDefault(r => r.Apply(f.ProblemField, f.ProblemValue, out _) != RuleAction.None);
+                    var updateRule = Updater.Rules.FirstOrDefault(r => r.Apply(f.ProblemField, f.ProblemValue, out _) != RuleAction.None);
+
+                    // record how often each reviewer rule was used with a failure
+                    foreach (var r in new[] { ignoreRule, updateRule })
+                        if (r != null)
+                        {
+                            lock(lockObj)
+                            {
+                                rulesUsed.AddOrUpdate(r, 1, (k, v) => Interlocked.Increment(ref v));
+                            }
+                        }
+
+                    // There are 2 conflicting rules for this input value (it should be updated and ignored!)
+                    if (ignoreRule != null && updateRule != null)
+                    {
+                        lock (lockObj)
+                        {
+                            // find an existing collision audit node for this input value
+                            var existing = colliding.Children.OfType<CollidingRulesNode>().FirstOrDefault(c => c.CollideOn[0].ProblemValue.Equals(f.ProblemValue));
+
+                            if (existing != null)
+                                existing.Add(f);
+                            else
+                                colliding.Children.Add(new CollidingRulesNode(ignoreRule, updateRule, f));
+                        }
+                    }
+
+                    // input value that doesn't match any system rules yet
+                    if (ignoreRule == null && updateRule == null)
+                    {
+                        lock (lockObj)
+                        {
+                            outstandingFailures.AddOrUpdate(f.ProblemValue, new OutstandingFailureNode(f, 1), (k, v) => {
+                                Interlocked.Increment(ref v.NumberOfTimesReported);
+                                return v;
+                            });
+                        }
+                    }
+                });
+
+            if (!result.IsCompleted)
+                throw new OperationCanceledException();
+
             SetProgress(progress,textProgress,done,max);
             
             var ignoreRulesUsed = rulesUsed.Where(r=>r.Key.Action == RuleAction.Ignore).ToList();

--- a/src/microservices/Microservices.IsIdentifiable/Rules/IsIdentifiableRule.cs
+++ b/src/microservices/Microservices.IsIdentifiable/Rules/IsIdentifiableRule.cs
@@ -72,7 +72,7 @@ namespace Microservices.IsIdentifiable.Rules
 
         public virtual RuleAction Apply(string fieldName, string fieldValue, out IEnumerable<FailurePart> badParts)
         {
-            badParts = new List<FailurePart>();
+            badParts = null;
 
             if (Action == RuleAction.None)
                 return RuleAction.None;
@@ -86,6 +86,9 @@ namespace Microservices.IsIdentifiable.Rules
             //if there is no column restriction or restriction applies to the current column
             if (string.IsNullOrWhiteSpace(IfColumn) || string.Equals(IfColumn,fieldName,StringComparison.InvariantCultureIgnoreCase))
             {
+                // only allocate this variable if there is an action to take
+                badParts = new List<FailurePart>();
+
                 //if there is no pattern
                 if (IfPattern == null)
                 {


### PR DESCRIPTION
## Proposed Changes

This adds parallelisation into the processing of rules in the IsIdentifiable reviewer aggregation tree UI.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [ ] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues

Relates to #754 . This is a first pass attempt to speed up reviewing using the tree aggregate view.