### PR TITLE
Fix - don't cover tagged builds

### DIFF
--- a/.azure-pipelines/jobs/tests.tmpl.yml
+++ b/.azure-pipelines/jobs/tests.tmpl.yml
@@ -68,6 +68,7 @@ jobs:
           - ${{ if eq( parameters.os, 'linux' ) }}:
             - task: PythonScript@0
               displayName: Upload coverage
+              condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
               inputs:
                 scriptSource: 'filePath'
                 scriptPath: .azure-pipelines/scripts/upload-coverage.py

--- a/news/789-bugfix.md
+++ b/news/789-bugfix.md
@@ -1,0 +1,1 @@
+Don't upload coverage for tagged builds


### PR DESCRIPTION
## Proposed Changes

Fixes a bug in the release pipeline where the branch name can't be determined (since it's a tagged build). Also we'll get coverage from the regular commit build.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
-