### PR TITLE
Fix ControlExchange creation in test suite

### DIFF
--- a/news/926-bugfix.md
+++ b/news/926-bugfix.md
@@ -1,0 +1,1 @@
+Fixes the current CI issues by restricting the creation of the ControlExchange to the RequiresRabbit test decorator.

--- a/tests/common/Smi.Common.Tests/DeadLetterMessagingTests/DeadLetterTestHelper.cs
+++ b/tests/common/Smi.Common.Tests/DeadLetterMessagingTests/DeadLetterTestHelper.cs
@@ -68,7 +68,6 @@ namespace Smi.Common.Tests.DeadLetterMessagingTests
             TestModel.QueueDeclare(RejectQueueName, true, false, false, queueProps);
             TestModel.QueueBind(RejectQueueName, RejectExchangeName, TestRoutingKey);
 
-            TestModel.ExchangeDeclare(GlobalOptions.RabbitOptions.RabbitMqControlExchangeName, "topic", true);
             TestModel.ExchangeDeclare(GlobalOptions.RabbitOptions.FatalLoggingExchange, "direct", true);
 
             TestProducer = new ProducerModel(RejectExchangeName, TestModel, props);

--- a/tests/common/Smi.Common.Tests/MicroserviceTester.cs
+++ b/tests/common/Smi.Common.Tests/MicroserviceTester.cs
@@ -55,11 +55,6 @@ namespace Smi.Common.Tests
             using (var con = Factory.CreateConnection())
             using (var model = con.CreateModel())
             {
-                //get rid of old exchanges
-                model.ExchangeDelete(rabbitOptions.RabbitMqControlExchangeName);
-                //create a new one
-                model.ExchangeDeclare(rabbitOptions.RabbitMqControlExchangeName, ExchangeType.Topic, true);
-
                 //setup a sender channel for each of the consumers you want to test sending messages to
                 foreach (ConsumerOptions consumer in peopleYouWantToSendMessagesTo)
                 {

--- a/tests/common/Smi.Common.Tests/RequiresRabbit.cs
+++ b/tests/common/Smi.Common.Tests/RequiresRabbit.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.IO;
 using System.Text;
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
 using YamlDotNet.Serialization;
 
 namespace Smi.Common.Tests
@@ -27,11 +28,11 @@ namespace Smi.Common.Tests
                 factory.SocketReadTimeout = 5000;
                 factory.SocketWriteTimeout = 5000;
 
-                IConnection conn = factory.CreateConnection();
-                conn.Close();
-
+                using var conn = factory.CreateConnection();
+                using var model = conn.CreateModel();
+                model.ExchangeDeclare("TEST.ControlExchange", ExchangeType.Topic, durable: true);
             }
-            catch (Exception e)
+            catch (BrokerUnreachableException e)
             {
                 StringBuilder sb = new StringBuilder();
 

--- a/tests/microservices/Microservices.DicomTagReader.Tests/DicomTagReaderTestHelper.cs
+++ b/tests/microservices/Microservices.DicomTagReader.Tests/DicomTagReaderTestHelper.cs
@@ -53,12 +53,10 @@ namespace Microservices.DicomTagReader.Tests
             SetUpDefaults();
 
             // Create the test Series/Image exchanges
-            Options.RabbitOptions.RabbitMqControlExchangeName = "TEST.ControlExchange";
             var tester = new MicroserviceTester(Options.RabbitOptions);
             tester.CreateExchange(Options.DicomTagReaderOptions.ImageProducerOptions.ExchangeName,  TestImageQueueName);
             tester.CreateExchange(Options.DicomTagReaderOptions.SeriesProducerOptions.ExchangeName, TestSeriesQueueName);
             tester.CreateExchange(Options.RabbitOptions.FatalLoggingExchange, null);
-            tester.CreateExchange(Options.RabbitOptions.RabbitMqControlExchangeName, null);
             tester.Shutdown();
 
             _testConnection = new ConnectionFactory


### PR DESCRIPTION
## Proposed Changes

Fixes the current CI issues by restricting the creation of the `ControlExchange` to the `RequiresRabbit` test decorator.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
-