### PR TITLE
remove system drawing common

### DIFF
--- a/news/968-bugfix.md
+++ b/news/968-bugfix.md
@@ -1,0 +1,1 @@
+Remove reference to System.Drawing.Common

--- a/src/microservices/Microservices.IsIdentifiable/Microservices.IsIdentifiable.csproj
+++ b/src/microservices/Microservices.IsIdentifiable/Microservices.IsIdentifiable.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="fo-dicom.Drawing" Version="[4.0.7]" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
     <PackageReference Include="Tesseract" Version="4.1.0-beta1" />

--- a/src/microservices/Microservices.IsIdentifiable/Microservices.IsIdentifiable.csproj
+++ b/src/microservices/Microservices.IsIdentifiable/Microservices.IsIdentifiable.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="fo-dicom.Drawing" Version="[4.0.7]" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
     <PackageReference Include="Tesseract" Version="4.1.0-beta1" />


### PR DESCRIPTION
## Proposed Changes

Remove single reference to `System.Drawing.Common`, which no longer has Linux support since v6.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
- Closes #961