### PR TITLE
Prevent directory setter emptying string for root usage fixing #921

### DIFF
--- a/news/976-bugfix.md
+++ b/news/976-bugfix.md
@@ -1,0 +1,1 @@
+Fix issue #921 - erroneous stripping of root path to empty string in GlobalOptions

--- a/src/common/Smi.Common/Options/GlobalOptions.cs
+++ b/src/common/Smi.Common/Options/GlobalOptions.cs
@@ -707,15 +707,15 @@ namespace Smi.Common.Options
 
         public string FileSystemRoot
         {
-            get { return _fileSystemRoot; }
-            set { _fileSystemRoot = value.TrimEnd('/', '\\'); }
+            get => _fileSystemRoot;
+            set => _fileSystemRoot = value.Length>1?value.TrimEnd('/', '\\'):value;
         }
 
         public string ExtractRoot
         {
-            get { return _extractRoot; }
+            get => _extractRoot;
             [UsedImplicitly]
-            set { _extractRoot = value.TrimEnd('/', '\\'); }
+            set => _extractRoot = value.Length>1?value.TrimEnd('/', '\\'):value;
         }
 
         public override string ToString()

--- a/tests/common/Smi.Common.Tests/Options/FileSystemOptionsTests.cs
+++ b/tests/common/Smi.Common.Tests/Options/FileSystemOptionsTests.cs
@@ -1,4 +1,5 @@
 using Smi.Common.Options;
+using NUnit.Framework;
 
 namespace Smi.Common.Tests.Options
 {

--- a/tests/common/Smi.Common.Tests/Options/FileSystemOptionsTests.cs
+++ b/tests/common/Smi.Common.Tests/Options/FileSystemOptionsTests.cs
@@ -1,0 +1,21 @@
+using Smi.Common.Options;
+
+namespace Smi.Common.Tests.Options
+{
+    public class FileSystemOptionsTests
+    {
+        [Test]
+        public void TestFileSystemOptions_AsLinuxRootDir()
+        {
+
+            var opts = new FileSystemOptions()
+            {
+                FileSystemRoot = "/",
+                ExtractRoot = "/",
+            };
+
+            Assert.AreEqual("/", opts.FileSystemRoot);
+            Assert.AreEqual("/", opts.ExtractRoot);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Fix issue #921 so target directories of '/' don't get stripped down to empty strings

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [X] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [X] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [X] Updated any relevant API documentation
- [X] Created or updated any tests if relevant
- [X] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [X] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [X] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are *expected* to be resolved with this PR. E.g.:

- Closes #921 
