### PR TITLE
disable coverage upload in CI

### DIFF
--- a/.azure-pipelines/jobs/tests.tmpl.yml
+++ b/.azure-pipelines/jobs/tests.tmpl.yml
@@ -65,20 +65,21 @@ jobs:
                   python \
                     utils/runDotnetTests.py \
                     "${{ parameters.os }}"
-          - ${{ if eq( parameters.os, 'linux' ) }}:
-            - task: PythonScript@0
-              displayName: Upload coverage
-              condition: |
-                and(
-                    succeeded(),
-                    not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
-                )
-              inputs:
-                scriptSource: 'filePath'
-                scriptPath: .azure-pipelines/scripts/upload-coverage.py
-                failOnStderr: true
-              env:
-                COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN)
+          # NOTE(rkm 2022-02-17) See https://github.com/SMI/SmiServices/issues/1049
+          # - ${{ if eq( parameters.os, 'linux' ) }}:
+          #   - task: PythonScript@0
+          #     displayName: Upload coverage
+          #     condition: |
+          #       and(
+          #           succeeded(),
+          #           not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+          #       )
+          #     inputs:
+          #       scriptSource: 'filePath'
+          #       scriptPath: .azure-pipelines/scripts/upload-coverage.py
+          #       failOnStderr: true
+          #     env:
+          #       COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN)
 
     - job: java_tests
       displayName: Java Tests

--- a/news/1050-bugfix.md
+++ b/news/1050-bugfix.md
@@ -1,0 +1,1 @@
+Disable coverage upload which is currently broken for .NET 6


### PR DESCRIPTION
## Proposed Changes

Disable the coverage upload from blocking all PRs until we develop a fix.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
