### PR TITLE
ctp: swap stderr reading and process.waitFor

### DIFF
--- a/news/1054-bugfix.md
+++ b/news/1054-bugfix.md
@@ -1,0 +1,1 @@
+Swap stderr reading and process.waitFor in SmiCtpProcessor to avoid a deadlock

--- a/src/microservices/com.smi.microservices.ctpanonymiser/src/main/java/org/smi/ctpanonymiser/execution/SmiCtpProcessor.java
+++ b/src/microservices/com.smi.microservices.ctpanonymiser/src/main/java/org/smi/ctpanonymiser/execution/SmiCtpProcessor.java
@@ -171,10 +171,10 @@ public class SmiCtpProcessor {
 			{
 				Process process = Runtime.getRuntime().exec(commandArray);
 				BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
-				process.waitFor();
-                stderr = errorReader.lines().collect(Collectors.joining(System.lineSeparator()));
+				stderr = errorReader.lines().collect(Collectors.joining(System.lineSeparator()));
 				errorReader.close();
-                rc =  process.exitValue();
+				process.waitFor();
+				rc =  process.exitValue();
 				process.destroy();
 			}
 			catch (Exception e) {


### PR DESCRIPTION
## Proposed Changes

This avoids a deadlock where the SRAnonTool could fill-up the stderr buffer before we attempt to read it.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues
