### PR TITLE
bump all HIC libraries to latest, and fo-dicom to 4.0.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,6 @@ jobs:
       run: |
         set -euxo pipefail
         rdmp_cli_ver=$(grep -F -m1 HIC.RDMP.Plugin src/common/Smi.Common/Smi.Common.csproj | sed -n 's/.*Version="\([0-9.]*\)".*/\1/p')
-        # NOTE(rkm 2022-03-01) Temp override to test --createdatabasetimeout
-        rdmp_cli_ver="7.0.7"
         echo "rdmp_cli_ver=v$rdmp_cli_ver" >> $GITHUB_ENV
     # Ref: https://github.com/actions/virtual-environments/issues/1282#issuecomment-668686268
     - name: "[windows] install SQL 2019 localdb"

--- a/bin/smi/writeDatabaseStrings.py
+++ b/bin/smi/writeDatabaseStrings.py
@@ -53,6 +53,7 @@ def main() -> int:
         f.write("Prefix: TEST_\n")
         f.write("Username: sa\n")
         f.write(f"Password: {args.db_password}\n")
+        f.write("ValidateCertificate: false\n")
         if not (os.name == "nt" and _is_ci()):
             f.write(f"MySql: server=127.0.0.1;Uid=root;Pwd={args.db_password};sslmode=None\n")
 

--- a/bin/smi/writeDatabaseStrings.py
+++ b/bin/smi/writeDatabaseStrings.py
@@ -53,7 +53,6 @@ def main() -> int:
         f.write("Prefix: TEST_\n")
         f.write("Username: sa\n")
         f.write(f"Password: {args.db_password}\n")
-        f.write("ValidateCertificate: false\n")
         if not (os.name == "nt" and _is_ci()):
             f.write(f"MySql: server=127.0.0.1;Uid=root;Pwd={args.db_password};sslmode=None\n")
 

--- a/src/common/Smi.Common/Smi.Common.csproj
+++ b/src/common/Smi.Common/Smi.Common.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Equ" Version="2.3.0" />
-    <PackageReference Include="fo-dicom.NetCore" Version="[4.0.7]" />
+    <PackageReference Include="fo-dicom.NetCore" Version="[4.0.8]" />
     <PackageReference Include="coveralls.io" Version="1.4.2" />
     <PackageReference Include="HIC.DicomTypeTranslation" Version="3.0.0" />
     <PackageReference Include="HIC.FAnsiSql" Version="2.0.3" />

--- a/src/common/Smi.Common/Smi.Common.csproj
+++ b/src/common/Smi.Common/Smi.Common.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="fo-dicom.NetCore" Version="[4.0.7]" />
     <PackageReference Include="coveralls.io" Version="1.4.2" />
     <PackageReference Include="HIC.DicomTypeTranslation" Version="3.0.0" />
-    <PackageReference Include="HIC.FAnsiSql" Version="2.0.2" />
-    <PackageReference Include="HIC.RDMP.Plugin" Version="7.0.3" />
+    <PackageReference Include="HIC.FAnsiSql" Version="2.0.3" />
+    <PackageReference Include="HIC.RDMP.Plugin" Version="7.0.7" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.13" />

--- a/src/microservices/Microservices.DicomRelationalMapper/Microservices.DicomRelationalMapper.csproj
+++ b/src/microservices/Microservices.DicomRelationalMapper/Microservices.DicomRelationalMapper.csproj
@@ -7,7 +7,7 @@
     <None Include="DicomRelationalMapper.cd" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HIC.RDMP.Dicom" Version="5.0.2" />
+    <PackageReference Include="HIC.RDMP.Dicom" Version="5.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\common\Smi.Common\Smi.Common.csproj" />

--- a/src/microservices/Microservices.IsIdentifiable/Microservices.IsIdentifiable.csproj
+++ b/src/microservices/Microservices.IsIdentifiable/Microservices.IsIdentifiable.csproj
@@ -26,7 +26,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="fo-dicom.Drawing" Version="[4.0.7]" />
+    <PackageReference Include="fo-dicom.Drawing" Version="[4.0.8]" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="9.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />

--- a/tests/common/Smi.Common.Tests/Smi.Common.Tests.csproj
+++ b/tests/common/Smi.Common.Tests/Smi.Common.Tests.csproj
@@ -22,8 +22,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HIC.BadMedicine.Dicom" Version="0.0.9" />
-    <PackageReference Include="HIC.RDMP.Plugin.Test" Version="7.0.3" />
+    <PackageReference Include="HIC.BadMedicine.Dicom" Version="0.0.10" />
+    <PackageReference Include="HIC.RDMP.Plugin.Test" Version="7.0.7" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.117" />

--- a/tests/microservices/Microservices.DicomRelationalMapper.Tests/DicomRelationalMapperTests.cs
+++ b/tests/microservices/Microservices.DicomRelationalMapper.Tests/DicomRelationalMapperTests.cs
@@ -58,7 +58,7 @@ namespace Microservices.DicomRelationalMapper.Tests
             using (var stream = File.OpenRead(fi.FullName))
             {    
                 dcm = DicomFile.Open(stream);
-                dcm.Dataset.AddOrUpdate(DicomTag.PrintRETIRED, "FISH");
+                dcm.Dataset.AddOrUpdate(DicomTag.Print, "FISH");
                 dcm.Dataset.AddOrUpdate(DicomTag.Date, new DateTime(2001,01,01));
                 dcm.Save(fi2.FullName);
             }
@@ -66,7 +66,7 @@ namespace Microservices.DicomRelationalMapper.Tests
             var adder = new TagColumnAdder(DicomTypeTranslaterReader.GetColumnNameForTag(DicomTag.Date,false), "datetime2", _helper.ImageTableInfo, new AcceptAllCheckNotifier());
             adder.Execute();
 
-            adder = new TagColumnAdder(DicomTypeTranslaterReader.GetColumnNameForTag(DicomTag.PrintRETIRED,false), "datetime2", _helper.ImageTableInfo, new AcceptAllCheckNotifier());
+            adder = new TagColumnAdder(DicomTypeTranslaterReader.GetColumnNameForTag(DicomTag.Print,false), "datetime2", _helper.ImageTableInfo, new AcceptAllCheckNotifier());
             adder.Execute();
             
             fi.Delete();


### PR DESCRIPTION
Replacing all the separate dependabot PRs with this one to reduce CI overhead.