### PR TITLE
Explicitly initialise LocalDB on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
       run: |
         Write-Host "Checking"
         $db = "(localdb)\MSSQLLocalDB"
+        SqlLocalDB.exe create MSSQLLocalDB -s
         sqlcmd -l 180 -S "$db" -Q "SELECT @@VERSION;"
         echo "rdmp_conn_str='$db'" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - name: "[windows] re-write database strings"


### PR DESCRIPTION
## Proposed Changes

Poke MSSQL before we start using it to reduce timeouts
(The existing SQLCMD invocation triggers this automatically, but sometimes it still isn't fast enough and things time out)

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [X] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [X] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [X] Updated any relevant API documentation
- [X] Created or updated any tests if relevant
- [X] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [X] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [X] Requested a review by one of the repository maintainers

## Issues

Reduces spurious CI failures on Windows