### PR TITLE
fixup built python wheel being empty

### DIFF
--- a/src/common/Smi_Common_Python/setup.py
+++ b/src/common/Smi_Common_Python/setup.py
@@ -37,17 +37,11 @@ def version_from_AssemblyInfo():
         ver = '0.0.0'
     return(ver)
 
-def find_source_path():
-    """ The path to the packages, so you can call setup.py from its own directory or from the repo root """
-    if isdir('src/common/Smi_Common_Python'):
-        return('src/common/Smi_Common_Python')
-    return('.')
-
 setup(
     name='SmiServices',
     version=version_from_AssemblyInfo(),
-    packages=find_packages(where=find_source_path(), exclude=('tests',)),
-    package_dir={'':find_source_path()},
+    packages=find_packages(where=dirname(__file__), exclude=('tests',)),
+    package_dir={'':dirname(__file__)},
     url='https://github.com/SMI/SmiServices',
     license='GPLv3',
     description='Common Python modules for SmiServices',


### PR DESCRIPTION
## Proposed Changes

The SmiServices (Smi_Common_Python) wheel is being built incorrectly, and does not include any of the python modules!

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues