### PR TITLE
wip: ensure mongodb service started on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,10 @@ jobs:
     - name: "[linux] start services"
       if: ${{ matrix.os == 'linux' }}
       run: ./bin/smi/startDockerLinux.py ${{ env.db-password }}
+    - name: "[windows] start MongoDB service"
+      if: ${{ matrix.os == 'windows' }}
+      shell: pwsh
+      run: Start-Service -Name mongodb
     - name: "[linux] re-write database strings"
       if: ${{ matrix.os == 'linux' }}
       run: |

--- a/news/1256-bugfix.md
+++ b/news/1256-bugfix.md
@@ -1,0 +1,1 @@
+Ensure MongoDB service started in Windows CI. Caused by https://github.com/actions/runner-images/issues/5949.


### PR DESCRIPTION
## Proposed Changes

Ensure MongoDB service started in Windows CI. Caused by https://github.com/actions/runner-images/issues/5949.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues