### PR TITLE
smi-py: constrain protobuf version for python3.6

### DIFF
--- a/news/1371-bugfix.md
+++ b/news/1371-bugfix.md
@@ -1,0 +1,1 @@
+Constrain protobuf version to "<=3.19.4", since this is the last version which supports python3.6 and we only have 3.6 on the live system.

--- a/src/common/Smi_Common_Python/requirements.txt
+++ b/src/common/Smi_Common_Python/requirements.txt
@@ -4,4 +4,4 @@ pydicom
 pymongo
 PyYAML
 mysql_connector_python
-protobuf>=3.20.2
+protobuf<=3.19.4


### PR DESCRIPTION
## Proposed Changes

`3.19.4` is the last version which supports python3.6. We are currently stuck with 3.6 on the live system.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues