### PR TITLE
Revert to setup-java@3.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Setup Java JDK
-      uses: actions/setup-java@v3.7.0
+      uses: actions/setup-java@v3.6.0
       with:
         java-version: ${{ env.java-version }}
         distribution: ${{ env.java-distribution }}

--- a/news/1399-bugfix.md
+++ b/news/1399-bugfix.md
@@ -1,0 +1,1 @@
+Revert to setup-java@3.6.0 due to disappearance of 3.7.0


### PR DESCRIPTION
Revert to latest Github setup-java action (3.6.0) since 3.7.0 has disappeared somehow, breaking CI


## Proposed Changes

Summarise your proposed changes here, including any notes for reviewers.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This ***must*** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are *expected* to be resolved with this PR. E.g.:

- Closes #\<issue-number>
- ...
