### PR TITLE
add rabbitmq management port to docker-compose

### DIFF
--- a/news/1430-bugfix.md
+++ b/news/1430-bugfix.md
@@ -1,0 +1,1 @@
+Add RabbitMQ management port to docker-compose files

--- a/utils/docker-compose/linux-dotnet.yml
+++ b/utils/docker-compose/linux-dotnet.yml
@@ -8,6 +8,7 @@ services:
     user: rabbitmq
     ports:
       - 5672:5672
+      - 15672:15672
   mariadb:
     container_name: mariadb
     image: mariadb:latest

--- a/utils/docker-compose/linux-java.yml
+++ b/utils/docker-compose/linux-java.yml
@@ -8,3 +8,4 @@ services:
     user: rabbitmq
     ports:
       - 5672:5672
+      - 15672:15672


### PR DESCRIPTION
## Proposed Changes

Adds RabbitMQ's management interface ports to the docker-compose files.

Discovered by @darshad-github .

## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Updated any relevant API documentation
-   [ ] Created or updated any tests if relevant
-   [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues

-