### PR TITLE
restrict mysql_connector_python version for py3.6

### DIFF
--- a/news/1431-bugfix.md
+++ b/news/1431-bugfix.md
@@ -1,0 +1,1 @@
+restrict mysql_connector_python version for python 3.6

--- a/src/common/Smi_Common_Python/requirements.txt
+++ b/src/common/Smi_Common_Python/requirements.txt
@@ -1,5 +1,5 @@
 deepmerge
-mysql_connector_python
+mysql_connector_python<8.0.29
 pika
 protobuf<3.20.0
 pydicom


### PR DESCRIPTION
## Proposed Changes

python3.6 support dropped in 8.0.29.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Updated any relevant API documentation
-   [ ] Created or updated any tests if relevant
-   [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues
-