### PR TITLE
[actions] replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,14 @@ jobs:
           set -euxo pipefail
           matrix="$(jq --compact-output . .github/workflows/envs.json)"
           echo $matrix
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
       - name: set build ref
         id: build_ref
         run: |
           set -euxo pipefail
           build_ref="$GITHUB_REF_NAME"
           [ "$GITHUB_REF_TYPE" != "tag" ] && build_ref="${GITHUB_SHA:0:6}"
-          echo "::set-output name=build_ref::$build_ref"
+          echo "build_ref=$build_ref" >> $GITHUB_OUTPUT
   smi:
     needs: [init]
     strategy:

--- a/news/1494-meta.md
+++ b/news/1494-meta.md
@@ -1,0 +1,1 @@
+[actions] replace deprecated set-output with GITHUB_OUTPUT


### PR DESCRIPTION
## Proposed Changes

As per [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Updated any relevant API documentation
-   [ ] Created or updated any tests if relevant
-   [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.:

- Closes #1449 