### PR TITLE
Change Mongo start timeout on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,7 @@ jobs:
         if: ${{ matrix.os == 'windows' }}
         shell: pwsh
         run: |
+          reg.exe add HKLM\System\CurrentControlSet\Control /v ServicesPipeTimeout /t REG_DWORD /d 300000 /f
           sc.exe config MongoDB start= auto
           sc.exe start MongoDB
       - name: setup .NET

--- a/news/1509-bugfix.md
+++ b/news/1509-bugfix.md
@@ -1,0 +1,1 @@
+Change Windows service control operation timeout to 300s since Mongo sometimes takes longer than the default 30s causing timeout errors otherwise


### PR DESCRIPTION
## Proposed Changes

Set a longer timeout for Mongo starting on Windows

## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Updated any relevant API documentation
-   [x] Created or updated any tests if relevant
-   [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues

Hopefully resolves intermittent launch failures on Github Actions caused by https://github.com/actions/runner-images/issues/5949