### PR TITLE
Replace LGTM badge wiith CodeQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## CI Status
 
 [![main](https://github.com/smi/SmiServices/actions/workflows/main.yml/badge.svg)](https://github.com/smi/SmiServices/actions/workflows/main.yml)
+[![CodeQL](https://github.com/SMI/SmiServices/actions/workflows/codeql.yml/badge.svg)](https://github.com/SMI/SmiServices/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/SMI/SmiServices/branch/master/graph/badge.svg?token=O6G26DHLEY)](https://codecov.io/gh/SMI/SmiServices)
 ![GitHub](https://img.shields.io/github/license/SMI/SmiServices)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/SMI/SmiServices.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/SMI/SmiServices/alerts/)
 
 Version: `5.3.0`
 


### PR DESCRIPTION
## Proposed Changes

- LGTM has been retired, so their status badge no longer works. Replacing with CodeQL status badge.
 
## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Updated any relevant API documentation
-   [x] Created or updated any tests if relevant
-   [ ] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.:

-   Closes #\<issue-number>
-   ...
