### PR TITLE
Add `HoldUnprocessableMessages` functionality

### DIFF
--- a/news/1701-feature.md
+++ b/news/1701-feature.md
@@ -1,0 +1,3 @@
+Adds the ability for consumers to optionally "hold" unprocessable messages so they are not returned to the queue.
+
+This enables debugging of problematic messages while allowing messages further back in the queue to be processed.

--- a/src/common/Smi.Common/Messaging/Consumer.cs
+++ b/src/common/Smi.Common/Messaging/Consumer.cs
@@ -31,6 +31,7 @@ namespace Smi.Common.Messaging
 
         private int _heldMessages = 0;
 
+        /// <inheritdoc/>
         public int QoSPrefetchCount { get; set; }
 
         /// <summary>

--- a/src/common/Smi.Common/Messaging/Consumer.cs
+++ b/src/common/Smi.Common/Messaging/Consumer.cs
@@ -29,6 +29,10 @@ namespace Smi.Common.Messaging
         /// <inheritdoc/>
         public bool HoldUnprocessableMessages { get; set; } = false;
 
+        private int _heldMessages = 0;
+
+        public int QoSPrefetchCount { get; set; }
+
         /// <summary>
         /// Event raised when Fatal method called
         /// </summary>
@@ -125,8 +129,12 @@ namespace Smi.Common.Messaging
             {
                 if (HoldUnprocessableMessages)
                 {
+                    ++_heldMessages;
                     var messageBody = Encoding.UTF8.GetString(deliverArgs.Body.Span);
-                    Logger.Warn($"Holding an unprocessable message: {messageBody}");
+                    Logger.Warn($"Holding an unprocessable message ({_heldMessages} total). Message body: {messageBody}");
+
+                    if (_heldMessages >= QoSPrefetchCount)
+                        Logger.Warn($"Now holding {_heldMessages} message, exceeding the configured BasicQos value of {QoSPrefetchCount}. No further messages will be delivered to this consumer!");
                 }
                 else
                 {

--- a/src/common/Smi.Common/Messaging/Consumer.cs
+++ b/src/common/Smi.Common/Messaging/Consumer.cs
@@ -29,7 +29,7 @@ namespace Smi.Common.Messaging
         /// <inheritdoc/>
         public bool HoldUnprocessableMessages { get; set; } = false;
 
-        private int _heldMessages = 0;
+        protected int _heldMessages = 0;
 
         /// <inheritdoc/>
         public int QoSPrefetchCount { get; set; }

--- a/src/common/Smi.Common/Messaging/Consumer.cs
+++ b/src/common/Smi.Common/Messaging/Consumer.cs
@@ -26,6 +26,9 @@ namespace Smi.Common.Messaging
         /// </summary>
         public int NackCount { get; private set; }
 
+        /// <inheritdoc/>
+        public bool HoldUnprocessableMessages { get; set; } = false;
+
         /// <summary>
         /// Event raised when Fatal method called
         /// </summary>
@@ -120,7 +123,15 @@ namespace Smi.Common.Messaging
             }
             catch (Exception e)
             {
-                Fatal("ProcessMessageImpl threw unhandled exception", e);
+                if (HoldUnprocessableMessages)
+                {
+                    var messageBody = Encoding.UTF8.GetString(deliverArgs.Body.Span);
+                    Logger.Warn($"Holding an unprocessable message: {messageBody}");
+                }
+                else
+                {
+                    Fatal("ProcessMessageImpl threw unhandled exception", e);
+                }
             }
         }
 

--- a/src/common/Smi.Common/Messaging/IConsumer.cs
+++ b/src/common/Smi.Common/Messaging/IConsumer.cs
@@ -2,6 +2,7 @@
 using Smi.Common.Events;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using Smi.Common.Options;
 
 namespace Smi.Common.Messaging
 {
@@ -31,5 +32,10 @@ namespace Smi.Common.Messaging
         /// Trigger a clean shutdown of worker threads etc
         /// </summary>
         void Shutdown();
+
+        /// <summary>
+        /// If set, consumer will not call Fatal when an unhandled exception occurs when processing a message. Requires <see cref="ConsumerOptions.AutoAck"/> to be false
+        /// </summary>
+        bool HoldUnprocessableMessages { get; set; }
     }
 }

--- a/src/common/Smi.Common/Messaging/IConsumer.cs
+++ b/src/common/Smi.Common/Messaging/IConsumer.cs
@@ -37,5 +37,10 @@ namespace Smi.Common.Messaging
         /// If set, consumer will not call Fatal when an unhandled exception occurs when processing a message. Requires <see cref="ConsumerOptions.AutoAck"/> to be false
         /// </summary>
         bool HoldUnprocessableMessages { get; set; }
+
+        /// <summary>
+        /// The BasicQos value configured on the <see cref="IModel"/>
+        /// </summary>
+        int QoSPrefetchCount { get; set; }
     }
 }

--- a/src/common/Smi.Common/Options/ConsumerOptions.cs
+++ b/src/common/Smi.Common/Options/ConsumerOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace Smi.Common.Options
 {
@@ -22,6 +22,11 @@ namespace Smi.Common.Options
         /// </summary>
         public bool AutoAck { get; set; }
 
+        /// <summary>
+        /// If set, consumer will not call Fatal when an unhandled exception occurs when processing a message, up to the <see cref="QoSPrefetchCount"/> limit. Requires <see cref="AutoAck"/> to be false
+        /// </summary>
+        public bool HoldUnprocessableMessages { get; set; }
+
 
         /// <summary>
         /// Verifies that the individual options have been populated
@@ -38,6 +43,7 @@ namespace Smi.Common.Options
             sb.Append("QueueName: " + QueueName);
             sb.Append(", AutoAck: " + AutoAck);
             sb.Append(", QoSPrefetchCount: " + QoSPrefetchCount);
+            sb.Append(", HoldUnprocessableMessages: " + HoldUnprocessableMessages);
             return sb.ToString();
         }
     }

--- a/src/common/Smi.Common/RabbitMQAdapter.cs
+++ b/src/common/Smi.Common/RabbitMQAdapter.cs
@@ -117,6 +117,7 @@ namespace Smi.Common
 
             var model = _connection.CreateModel();
             model.BasicQos(0, consumerOptions.QoSPrefetchCount, false);
+            consumer.QoSPrefetchCount = consumerOptions.QoSPrefetchCount;
 
             // Check queue exists
             try

--- a/src/common/Smi.Common/RabbitMQAdapter.cs
+++ b/src/common/Smi.Common/RabbitMQAdapter.cs
@@ -168,11 +168,14 @@ namespace Smi.Common
                 _hostFatalHandler?.Invoke(s, e);
             };
 
+            if (consumerOptions.HoldUnprocessableMessages && !consumerOptions.AutoAck)
+                consumer.HoldUnprocessableMessages = true;
+
             model.BasicConsume(ebc, consumerOptions.QueueName, consumerOptions.AutoAck);
             _logger.Debug($"Consumer task started [QueueName={consumerOptions?.QueueName}]");
             return taskId;
         }
-        
+
         /// <summary>
         ///
         /// </summary>


### PR DESCRIPTION
## Proposed Changes

Adds the ability for consumers to optionally "hold" unprocessable messages so they are not returned to the queue.

This enables debugging of problematic messages while allowing messages further back in the queue to be processed.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTING.md) guidelines for this repository
-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Updated any relevant API documentation
-   [ ] Created or updated any tests if relevant
-   [x] Created a [news](https://github.com/SMI/SmiServices/blob/master/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/master/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues

-