### PR TITLE
SR handling supports the odd structure inside Dermatology SRs

### DIFF
--- a/news/1748-feature.md
+++ b/news/1748-feature.md
@@ -1,0 +1,1 @@
+Add support for Dermatology SRs

--- a/src/common/Smi_Common_Python/README.md
+++ b/src/common/Smi_Common_Python/README.md
@@ -16,9 +16,9 @@ mysql-connector-python (which requires six, protobuf, dnspython) for IdentifierM
 
 ## Installation
 
-Run `python3 setup.py bdist_wheel` to create `Smi_Services_Python-0.0.0-py3-none-any.whl`
+Run `python3 ./setup.py bdist_wheel` to create `Smi_Services_Python-0.0.0-py3-none-any.whl`
 
-Run `python3 setup.py install` to install (including dependencies) into your python site-packages
+Run `python3 ./setup.py install` to install (including dependencies) into your python site-packages
 (whether that be global or inside a current virtualenv).
 
 Note that the version number is read from AssemblyInfo.cs in a parent directory.

--- a/src/common/Smi_Common_Python/README.md
+++ b/src/common/Smi_Common_Python/README.md
@@ -154,24 +154,28 @@ Some utility functions are used by the DicomText module.
 # Parsing Structured Reports
 
 Generally speaking you can work with Structured Reports in any of these ways:
-* dcm2json - outputs a JSON document (you can parse with `jq`, and use our
-`dicom_tag_string_replace.py` script to turn tag numbers into names)
-* read it with pydicom
-* read it from MongoDB
+
+-   dcm2json - outputs a JSON document (you can parse with `jq`, and use our
+    `dicom_tag_string_replace.py` script to turn tag numbers into names)
+-   read it with pydicom
+-   read it from MongoDB
 
 `dcm2json` - Depending on the source of the JSON, use `.val` or `.Value[0]`:
+
 ```
 dcm2json file.dcm | dicom_tag_string_replace.py | jq dicom_tag_string_replace.py | \
  jq '..| select(.vr == "ST" or .vr == "PN" or .vr == "LO" or .vr == "UT" or .vr == "DA")? | .val'
 ```
 
 `pydicom` - convert to a JSON dict
+
 ```
 dicom_raw = pydicom.dcmread(filename)
 dicom_raw_json = dicom_raw.to_json_dict()
 ```
 
 `MongoDB` - using the SmiServices Mongo helper
+
 ```
 mongodb = Mongo.SmiPyMongoCollection(mongo_host)
 mongodb.setImageCollection('SR')
@@ -207,6 +211,7 @@ dicomtext.write_redacted_text_into_dicom_file(args.output_dcm)
 ## Method 2 - use the StructuredReport module
 
 From a JSON file (e.g. output by dcm2json):
+
 ```
 with open('/lesion1-srdocument-medical.dcm.json') as fd:
   jdoc = json.load(fd)
@@ -215,6 +220,7 @@ sr.SR_parse(jdoc, 'doc', sys.stdout)
 ```
 
 From a DICOM file:
+
 ```
 ds = pydicom.dcmread('/lesion1-srdocument-medical.dcm')
 sr = StructuredReport.StructuredReport()
@@ -222,12 +228,14 @@ sr.SR_parse(ds.to_json_dict(), 'doc_name', sys.stdout)
 ```
 
 From MongoDB, get mongojson as above:
+
 ```
 SR.SR_parse(mongojson, document_name, output_fd)
 ```
 
 Agreed, the output to an open file may be inconvenient
 so here's a temporary file tip:
+
 ```
 with TemporaryFile(mode='w+', encoding='utf-8') as fd:
     SR.SR_parse(json_dict, document_name, fd)

--- a/src/common/Smi_Common_Python/README.md
+++ b/src/common/Smi_Common_Python/README.md
@@ -153,24 +153,89 @@ Some utility functions are used by the DicomText module.
 
 # Parsing Structured Reports
 
+Generally speaking you can work with Structured Reports in any of these ways:
+* dcm2json - outputs a JSON document (you can parse with `jq`, and use our
+`dicom_tag_string_replace.py` script to turn tag numbers into names)
+* read it with pydicom
+* read it from MongoDB
+
+`dcm2json` - Depending on the source of the JSON, use `.val` or `.Value[0]`:
 ```
-# Read the DICOM file manually and extract to JSON
-  dicom_raw = pydicom.dcmread(filename)
-  dicom_raw_json = dicom_raw.to_json_dict(None, 0)
-# OR read the JSON from MongoDB
-  mongodb = Mongo.SmiPyMongoCollection(mongo_host)
-  mongodb.setImageCollection('SR')
-  mongojson = mongodb.DicomFilePathToJSON(args.input)
+dcm2json file.dcm | dicom_tag_string_replace.py | jq dicom_tag_string_replace.py | \
+ jq '..| select(.vr == "ST" or .vr == "PN" or .vr == "LO" or .vr == "UT" or .vr == "DA")? | .val'
 ```
 
-## Method 1 - use the StructuredReport module
+`pydicom` - convert to a JSON dict
+```
+dicom_raw = pydicom.dcmread(filename)
+dicom_raw_json = dicom_raw.to_json_dict()
+```
+
+`MongoDB` - using the SmiServices Mongo helper
+```
+mongodb = Mongo.SmiPyMongoCollection(mongo_host)
+mongodb.setImageCollection('SR')
+mongojson = mongodb.DicomFilePathToJSON(filepath)
+```
+
+To parse the actual SR document you can use either `DicomText` which reads
+a DICOM file, and can parse the text, return the parsed text, and redact
+the text given a list of redaction offsets, saving a new redacted DICOM file.
+
+Alternatively the `StructuredReport` module can parse any of the various
+flavours of JSON (from dcm2json, from pydicom, from mongodb).
+
+## Method 1 - use the DicomText module
+
+To read an original:
 
 ```
-  SR.SR_parse(dicom_raw_json, document_name, output_fd)
-  SR.SR_parse(mongojson, document_name, output_fd)
+dicomtext = DicomText.DicomText(filename)
+dicomtext.parse()
+txt = dicomtext.text()
 ```
 
-## Method 2 - use the pydicom walk method
+To redact, given an input_xml file:
+
+```
+xmlroot = xml.etree.ElementTree.parse(args.input_xml).getroot()
+xmldictlist = Knowtator.annotation_xml_to_dict(xmlroot)
+dicomtext.redact(xmldictlist)
+dicomtext.write_redacted_text_into_dicom_file(args.output_dcm)
+```
+
+## Method 2 - use the StructuredReport module
+
+From a JSON file (e.g. output by dcm2json):
+```
+with open('/lesion1-srdocument-medical.dcm.json') as fd:
+  jdoc = json.load(fd)
+sr = StructuredReport.StructuredReport()
+sr.SR_parse(jdoc, 'doc', sys.stdout)
+```
+
+From a DICOM file:
+```
+ds = pydicom.dcmread('/lesion1-srdocument-medical.dcm')
+sr = StructuredReport.StructuredReport()
+sr.SR_parse(ds.to_json_dict(), 'doc_name', sys.stdout)
+```
+
+From MongoDB, get mongojson as above:
+```
+SR.SR_parse(mongojson, document_name, output_fd)
+```
+
+Agreed, the output to an open file may be inconvenient
+so here's a temporary file tip:
+```
+with TemporaryFile(mode='w+', encoding='utf-8') as fd:
+    SR.SR_parse(json_dict, document_name, fd)
+    fd.seek(0)
+    fd.read()
+```
+
+## Method 3 - use the pydicom walk method
 
 ```
 def decode(filename):
@@ -191,7 +256,7 @@ def decode(filename):
     	content_sequence_item.walk(dataset_callback)
 ```
 
-## Method 3 - use the pydicom recurse_tree method
+## Method 4 - use the pydicom recurse_tree method
 
 ```
 def decode(filename):
@@ -228,22 +293,4 @@ def decode(filename):
     # (to recurse the whole DICOM pass dicom_raw as second param).
     for content_sequence_item in dicom_raw.ContentSequence:
     	recurse_tree(None, content_sequence_item, '')
-```
-
-## Method 4 - use the DicomText module
-
-To read an original:
-
-```
-    dicomtext = DicomText.DicomText(input)
-    dicomtext.parse()
-```
-
-To redact, given an input_xml file:
-
-```
-    xmlroot = xml.etree.ElementTree.parse(args.input_xml).getroot()
-    xmldictlist = Knowtator.annotation_xml_to_dict(xmlroot)
-    dicomtext.redact(xmldictlist)
-    dicomtext.write_redacted_text_into_dicom_file(args.output_dcm)
 ```

--- a/src/common/Smi_Common_Python/SmiServices/DicomText.py
+++ b/src/common/Smi_Common_Python/SmiServices/DicomText.py
@@ -57,7 +57,8 @@ class DicomText:
         include_header = _include_header, \
         replace_HTML_entities = _replace_HTML_entities, \
         replace_HTML_char = _replace_HTML_char, \
-        replace_newline_char = _replace_newline_char):
+        replace_newline_char = _replace_newline_char,
+        include_unexpected_tags = _include_unexpected_tags):
         """ The DICOM file is read during construction.
         If include_header is True some DICOM header fields are output (default True).
         If replace_HTML_entities is True then all HTML is replaced by dots (default True).
@@ -77,6 +78,7 @@ class DicomText:
         self._replace_HTML_entities = replace_HTML_entities
         self._replace_HTML_char = replace_HTML_char
         self._replace_newline_char = replace_newline_char
+        self._include_unexpected_tags = include_unexpected_tags
         # XXX do we need to decode the text?
         self._dicom_raw.decode()
 

--- a/src/common/Smi_Common_Python/SmiServices/StructuredReport.py
+++ b/src/common/Smi_Common_Python/SmiServices/StructuredReport.py
@@ -348,6 +348,9 @@ class StructuredReport:
         # If there is no value the do not print anything at all
         if valstr == None or valstr == '':
             return
+        # If we end up with an integer convert to string
+        if not isinstance(valstr, str):
+            valstr = str(valstr)
         # XXX should we be using Dicom.sr_decode_PNAME if it's a PN/PNAME ???
         # Replace CRs with LF
         valstr = re.sub('\r+', '\n', valstr)

--- a/src/common/Smi_Common_Python/SmiServices/StructuredReport.py
+++ b/src/common/Smi_Common_Python/SmiServices/StructuredReport.py
@@ -487,7 +487,7 @@ class StructuredReport:
         # except for a ConceptSequence which will be done below.
         has_conceptseq_at_root_level = has_tag(json_dict, 'ValueType')
         for json_key in json_dict:
-            if has_conceptseq_at_root_level and not (tag_is(json_key, 'ConceptCodeSequence') or tag_is(json_key, 'ConceptNameCodeSequence')):
+            if not has_conceptseq_at_root_level or (not (tag_is(json_key, 'ConceptCodeSequence') or tag_is(json_key, 'ConceptNameCodeSequence'))):
                 self._SR_parse_key(json_dict, json_key, fp)
 
         # If it has elements which should be inside a ContentSequence but aren't:


### PR DESCRIPTION
## Proposed Changes

SR handling supports the odd structure inside Dermatology SRs

Some additional Code Sequence types are present, and very unusually a Code Sequence appears at the root level in the document structure rather than inside a sequence as you might normally expect.

Note that the value is taken from CodeMeaning but if you wanted the actual code itself (for example it's an ICD10 code) then it would be easy to change.

## Types of changes

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update (if none of the other choices apply)
    -   In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

-   [X] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTING.md) guidelines for this repository
-   [X] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Updated any relevant API documentation
-   [x] Created or updated any tests if relevant
-   [x] Created a [news](https://github.com/SMI/SmiServices/blob/main/news/README.md) file
    -   NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
-   [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTORS.md) file 🚀
-   [x] Requested a review by one of the repository maintainers

## Issues

If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.:

-   Closes #\<issue-number>
-   ...
