### PR TITLE
Set correct database in QueryToExecute

### DIFF
--- a/news/1887-bugfix.md
+++ b/news/1887-bugfix.md
@@ -1,0 +1,1 @@
+Pass setInitialDatabase as true to GetDistinctLiveDatabaseServer to ensure that the correct database is used when connecting to Postgres

--- a/src/microservices/Microservices.CohortExtractor/Execution/RequestFulfillers/QueryToExecute.cs
+++ b/src/microservices/Microservices.CohortExtractor/Execution/RequestFulfillers/QueryToExecute.cs
@@ -41,7 +41,7 @@ namespace Microservices.CohortExtractor.Execution.RequestFulfillers
         {
             Columns = columns;
             KeyTag = keyTag;
-            Server = columns.Catalogue.GetDistinctLiveDatabaseServer(DataAccessContext.DataExport, false);
+            Server = columns.Catalogue.GetDistinctLiveDatabaseServer(DataAccessContext.DataExport, setInitialDatabase: true);
         }
 
         /// <summary>

--- a/tests/microservices/Microservices.CohortExtractor.Tests/FromCataloguesExtractionRequestFulfillerUnitTests.cs
+++ b/tests/microservices/Microservices.CohortExtractor.Tests/FromCataloguesExtractionRequestFulfillerUnitTests.cs
@@ -247,6 +247,7 @@ namespace Microservices.CohortExtractor.Tests
             var ci = new CatalogueItem(repo, c, col);
             var ti = new TableInfo(repo, "ff");
             ti.Server = "ff";
+            ti.Database = "db";
             var ei = new ExtractionInformation(repo, ci, new ColumnInfo(repo,col,"varchar(10)",ti), col);
         }
     }


### PR DESCRIPTION
## Proposed Changes

<!-- Summarise your proposed changes here, including any notes for reviewers -->

Pass setInitialDatabase as true to GetDistinctLiveDatabaseServer to ensure that the correct database is used when connecting to Postgres.

## Types of changes

<!-- What types of changes does your code introduce? Tick all that apply. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/main/news/README.md) file
  - NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by the `@SMI/Reviewers` team

## Issues

<!-- If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.: -->

Fixes #1885
