### PR TITLE
Fix handling of GlobalOptions deserializing to null

### DIFF
--- a/news/1917-bugfix.md
+++ b/news/1917-bugfix.md
@@ -1,0 +1,1 @@
+Fix handling of GlobalOptions deserializing to null

--- a/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
+++ b/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using YamlDotNet.Serialization;
 
 namespace SmiServices.Common.Options
@@ -28,18 +29,21 @@ namespace SmiServices.Common.Options
         /// </summary>
         /// <param name="hostProcessName"></param>
         /// <param name="configFilePath"></param>
+        /// <param name="fileSystem"></param>
         /// <returns></returns>
-        public GlobalOptions Load(string hostProcessName, string configFilePath = "default.yaml")
+        public GlobalOptions Load(string hostProcessName, string configFilePath = "default.yaml", IFileSystem? fileSystem = null)
         {
+            fileSystem ??= new FileSystem();
+
             IDeserializer deserializer = new DeserializerBuilder()
                                     .WithObjectFactory(GetGlobalOption)
                                     .IgnoreUnmatchedProperties()
                                     .Build();
 
-            if (!File.Exists(configFilePath))
+            if (!fileSystem.File.Exists(configFilePath))
                 throw new ArgumentException($"Could not find config file '{configFilePath}'");
 
-            string yamlContents = File.ReadAllText(configFilePath);
+            string yamlContents = fileSystem.File.ReadAllText(configFilePath);
 
             using var sr = new StringReader(yamlContents);
             var globals = deserializer.Deserialize<GlobalOptions>(sr);
@@ -70,10 +74,11 @@ namespace SmiServices.Common.Options
         /// </summary>
         /// <param name="hostProcessName"></param>
         /// <param name="cliOptions"></param>
+        /// <param name="fileSystem"></param>
         /// <returns></returns>
-        public GlobalOptions Load(string hostProcessName, CliOptions cliOptions)
+        public GlobalOptions Load(string hostProcessName, CliOptions cliOptions, IFileSystem? fileSystem = null)
         {
-            GlobalOptions globalOptions = Load(hostProcessName, cliOptions.YamlFile);
+            GlobalOptions globalOptions = Load(hostProcessName, cliOptions.YamlFile, fileSystem);
 
             // The above Load call does the decoration - don't do it here.
             return globalOptions;

--- a/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
+++ b/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
@@ -47,9 +47,6 @@ namespace SmiServices.Common.Options
             var globals = deserializer.Deserialize<GlobalOptions?>(yamlContents)
                 ?? throw new Exception("Did not deserialize a GlobalOptions object from the provided YAML file. Does it contain at least one valid key?");
 
-            if (globals.LoggingOptions == null)
-                throw new Exception($"Loaded YAML did not contain a {nameof(globals.LoggingOptions)} key. Did you provide a valid config file?");
-
             globals.HostProcessName = hostProcessName;
 
             return Decorate(globals);

--- a/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
+++ b/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
@@ -46,7 +46,10 @@ namespace SmiServices.Common.Options
             string yamlContents = fileSystem.File.ReadAllText(configFilePath);
 
             using var sr = new StringReader(yamlContents);
-            var globals = deserializer.Deserialize<GlobalOptions>(sr);
+            var globals = deserializer.Deserialize<GlobalOptions?>(sr);
+
+            if (globals == null)
+                throw new Exception($"Did not deserialize a GlobalOptions object from the provided YAML file. Does it contain at least one valid key?");
 
             if (globals.LoggingOptions == null)
                 throw new Exception($"Loaded YAML did not contain a {nameof(globals.LoggingOptions)} key. Did you provide a valid config file?");

--- a/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
+++ b/src/SmiServices/Common/Options/GlobalOptionsFactory.cs
@@ -43,13 +43,9 @@ namespace SmiServices.Common.Options
             if (!fileSystem.File.Exists(configFilePath))
                 throw new ArgumentException($"Could not find config file '{configFilePath}'");
 
-            string yamlContents = fileSystem.File.ReadAllText(configFilePath);
-
-            using var sr = new StringReader(yamlContents);
-            var globals = deserializer.Deserialize<GlobalOptions?>(sr);
-
-            if (globals == null)
-                throw new Exception($"Did not deserialize a GlobalOptions object from the provided YAML file. Does it contain at least one valid key?");
+            var yamlContents = fileSystem.File.ReadAllText(configFilePath);
+            var globals = deserializer.Deserialize<GlobalOptions?>(yamlContents)
+                ?? throw new Exception("Did not deserialize a GlobalOptions object from the provided YAML file. Does it contain at least one valid key?");
 
             if (globals.LoggingOptions == null)
                 throw new Exception($"Loaded YAML did not contain a {nameof(globals.LoggingOptions)} key. Did you provide a valid config file?");

--- a/tests/SmiServices.IntegrationTests/Common/OptionsTests.cs
+++ b/tests/SmiServices.IntegrationTests/Common/OptionsTests.cs
@@ -94,5 +94,15 @@ namespace SmiServices.UnitTests.Common
             var exc = Assert.Throws<Exception>(() => globalOptionsFactory.Load(nameof(GlobalOptionsFactory_Load_EmptyFile_ThrowsWithUsefulMessage), "foo.yaml", fileSystem));
             Assert.That(exc.Message, Is.EqualTo("Did not deserialize a GlobalOptions object from the provided YAML file. Does it contain at least one valid key?"));
         }
+
+        [Test]
+        public void GlobalOptionsFactory_Load_MissingFile_ThrowsWithUsefulMessage()
+        {
+            var fileSystem = new MockFileSystem();
+            var globalOptionsFactory = new GlobalOptionsFactory();
+
+            var exc = Assert.Throws<ArgumentException>(() => globalOptionsFactory.Load(nameof(GlobalOptionsFactory_Load_EmptyFile_ThrowsWithUsefulMessage), "foo.yaml", fileSystem));
+            Assert.That(exc.Message, Is.EqualTo("Could not find config file 'foo.yaml'"));
+        }
     }
 }

--- a/tests/SmiServices.IntegrationTests/Common/OptionsTests.cs
+++ b/tests/SmiServices.IntegrationTests/Common/OptionsTests.cs
@@ -1,8 +1,7 @@
-
 using NUnit.Framework;
 using SmiServices.Common.Options;
 using System;
-using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
 
 namespace SmiServices.UnitTests.Common
 {
@@ -83,6 +82,17 @@ namespace SmiServices.UnitTests.Common
                 Assert.That(g.MongoDatabases!.DicomStoreOptions!.DatabaseName, Is.EqualTo("FFFFF"));
                 Assert.That(g.MongoDatabases.ExtractionStoreOptions!.DatabaseName, Is.EqualTo("FFFFF"));
             });
+        }
+
+        [Test]
+        public void GlobalOptionsFactory_Load_EmptyFile_ThrowsWithUsefulMessage()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.Create("foo.yaml");
+            var globalOptionsFactory = new GlobalOptionsFactory();
+
+            var exc = Assert.Throws<Exception>(() => globalOptionsFactory.Load(nameof(GlobalOptionsFactory_Load_EmptyFile_ThrowsWithUsefulMessage), "foo.yaml", fileSystem));
+            Assert.That(exc.Message, Is.EqualTo("Did not deserialize a GlobalOptions object from the provided YAML file. Does it contain at least one valid key?"));
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Summarise your proposed changes here, including any notes for reviewers -->

Provides a much better message in some cases e.g., specifying an empty file.

This highlighted that the Nullable feature doesn't save us unless we specify that the template type is also nullable.

## Types of changes

<!-- What types of changes does your code introduce? Tick all that apply. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/main/news/README.md) file
  - NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by the `@SMI/Reviewers` team

## Issues

<!-- If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.: -->
