### PR TITLE
bump sqlserver to 2022 in CI to fix startup crash

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -133,7 +133,8 @@ def start_containers(
         except subprocess.CalledProcessError:
             # NOTE(rkm 2022-03-01) Print container logs when a check fails
             cmd = (
-                f"{docker}-compose",
+                f"{docker}",
+                "compose",
                 "-f", compose_file,
                 "logs"
             )

--- a/bin/common.py
+++ b/bin/common.py
@@ -114,6 +114,7 @@ def start_containers(
         "compose",
         "-f", compose_file,
         "up",
+        "--quiet-pull",
         "--detach",
         "--force-recreate",
     )

--- a/bin/smi/startDockerLinux.py
+++ b/bin/smi/startDockerLinux.py
@@ -33,7 +33,7 @@ def main() -> int:
             "rabbitmq rabbitmq-diagnostics -q ping",
             f"mariadb mysqladmin -uroot -p{args.db_password} status",
             "redis /usr/local/bin/redis-cli PING",
-            f"mssql /opt/mssql-tools18/bin/sqlcmd -U sa -P {args.db_password} -l 1 -Q 'SELECT @@VERSION'",
+            f"mssql /opt/mssql-tools18/bin/sqlcmd -U sa -P {args.db_password} -No -l 1 -Q 'SELECT @@VERSION'",
             "mongodb /usr/bin/mongo --quiet --eval 'db.stats().ok'",
         ),
     )

--- a/bin/smi/startDockerLinux.py
+++ b/bin/smi/startDockerLinux.py
@@ -33,7 +33,7 @@ def main() -> int:
             "rabbitmq rabbitmq-diagnostics -q ping",
             f"mariadb mysqladmin -uroot -p{args.db_password} status",
             "redis /usr/local/bin/redis-cli PING",
-            f"mssql /opt/mssql-tools/bin/sqlcmd -U sa -P {args.db_password} -l 1 -Q 'SELECT @@VERSION'",
+            f"mssql /opt/mssql-tools18/bin/sqlcmd -U sa -P {args.db_password} -l 1 -Q 'SELECT @@VERSION'",
             "mongodb /usr/bin/mongo --quiet --eval 'db.stats().ok'",
         ),
     )

--- a/news/1940-bugfix.md
+++ b/news/1940-bugfix.md
@@ -1,0 +1,1 @@
+Bump sqlserver to 2022 in CI to fix startup crash

--- a/utils/docker-compose/linux-dotnet.yml
+++ b/utils/docker-compose/linux-dotnet.yml
@@ -23,7 +23,7 @@ services:
       - 6379:6379
   mssql:
     container_name: mssql
-    image: mcr.microsoft.com/mssql/server:2017-latest
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=${DB_PASSWORD:-YourStrongPassw0rd}

--- a/utils/docker-compose/linux-dotnet.yml.lock
+++ b/utils/docker-compose/linux-dotnet.yml.lock
@@ -15,8 +15,8 @@
 			},
 			{
 				"name": "mcr.microsoft.com/mssql/server",
-				"tag": "2017-latest",
-				"digest": "c9832ca564c8410bf13a7d6276a0bf6f5d83d0f6a15c6a5004ba07a04bf93920",
+				"tag": "2022-latest",
+				"digest": "8ca3956bcb1f3373e5b04f946a527abb24c07655c2044bd5c9c8852d02fbec7c",
 				"service": "mssql"
 			},
 			{


### PR DESCRIPTION
## Proposed Changes

<!-- Summarise your proposed changes here, including any notes for reviewers -->

Seems that `mcr.microsoft.com/mssql/server:2017-latest` no longer works on the Ubuntu CI runner. Possibly the same issue as https://github.com/microsoft/mssql-docker/issues/899.

This bumps the image to 2022-latest and fixes related issues.

## Types of changes

<!-- What types of changes does your code introduce? Tick all that apply. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [ ] Updated any relevant API documentation
- [ ] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/main/news/README.md) file
  - NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by the `@SMI/Reviewers` team

## Issues

<!-- If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.: -->
