### PR TITLE
Feature/extraction rate limiting

### DIFF
--- a/news/1945-feature.md
+++ b/news/1945-feature.md
@@ -1,0 +1,3 @@
+Add a publish timeout backoff mechanism to ProducerModel, allowing control over message publishing timeout behaviour. This can be enabled by setting `BackoffProviderType` in any `ProducerOptions` config. Currently implemented types are:
+- StaticBackoffProvider (1 minute flat timeout)
+- ExponentialBackoffProvider (1 minute initial, doubling after each timeout)

--- a/news/1945-feature.md
+++ b/news/1945-feature.md
@@ -1,3 +1,4 @@
 Add a publish timeout backoff mechanism to ProducerModel, allowing control over message publishing timeout behaviour. This can be enabled by setting `BackoffProviderType` in any `ProducerOptions` config. Currently implemented types are:
+
 - StaticBackoffProvider (1 minute flat timeout)
 - ExponentialBackoffProvider (1 minute initial, doubling after each timeout)

--- a/src/SmiServices/Common/Messaging/BackoffProviderFactory.cs
+++ b/src/SmiServices/Common/Messaging/BackoffProviderFactory.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace SmiServices.Common.Messaging;
+
+internal static class BackoffProviderFactory
+{
+    public static IBackoffProvider Create(string typename)
+    {
+        if (!Enum.TryParse(typename, ignoreCase: true, out BackoffProviderType backoffProviderType))
+            throw new ArgumentException($"Could not parse '{typename}' to a valid BackoffProviderType");
+
+        return backoffProviderType switch
+        {
+            BackoffProviderType.StaticBackoffProvider => new StaticBackoffProvider(),
+            BackoffProviderType.ExponentialBackoffProvider => new ExponentialBackoffProvider(),
+            _ => throw new NotImplementedException($"No case for BackoffProviderType '{backoffProviderType}'"),
+        };
+    }
+}

--- a/src/SmiServices/Common/Messaging/BackoffProviderType.cs
+++ b/src/SmiServices/Common/Messaging/BackoffProviderType.cs
@@ -1,0 +1,8 @@
+namespace SmiServices.Common.Messaging;
+
+public enum BackoffProviderType
+{
+    None = 0,
+    StaticBackoffProvider,
+    ExponentialBackoffProvider,
+}

--- a/src/SmiServices/Common/Messaging/BatchProducerModel.cs
+++ b/src/SmiServices/Common/Messaging/BatchProducerModel.cs
@@ -10,8 +10,8 @@ namespace SmiServices.Common.Messaging
     /// </summary>
     public class BatchProducerModel : ProducerModel
     {
-        public BatchProducerModel(string exchangeName, IModel model, IBasicProperties properties, int maxPublishAttempts = 1)
-            : base(exchangeName, model, properties, maxPublishAttempts) { }
+        public BatchProducerModel(string exchangeName, IModel model, IBasicProperties properties, int maxPublishAttempts = 1, IBackoffProvider? backoffProvider = null)
+            : base(exchangeName, model, properties, maxPublishAttempts, backoffProvider) { }
 
 
         /// <summary>

--- a/src/SmiServices/Common/Messaging/ExponentialBackoffProvider.cs
+++ b/src/SmiServices/Common/Messaging/ExponentialBackoffProvider.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace SmiServices.Common.Messaging;
+
+public class ExponentialBackoffProvider : IBackoffProvider
+{
+    private readonly TimeSpan _initialBackoff;
+    private TimeSpan _currentBackoff;
+
+    public ExponentialBackoffProvider(TimeSpan? initialBackoff = null)
+    {
+        _initialBackoff = initialBackoff ?? new TimeSpan(hours: 0, minutes: 1, seconds: 0);
+        Reset();
+    }
+
+    public TimeSpan GetNextBackoff()
+    {
+        var b = _currentBackoff;
+        _currentBackoff *= 2;
+        return b;
+    }
+
+    public void Reset()
+    {
+        _currentBackoff = _initialBackoff;
+    }
+}

--- a/src/SmiServices/Common/Messaging/IBackoffProvider.cs
+++ b/src/SmiServices/Common/Messaging/IBackoffProvider.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace SmiServices.Common.Messaging;
+
+public interface IBackoffProvider
+{
+    TimeSpan GetNextBackoff();
+
+    void Reset();
+}

--- a/src/SmiServices/Common/Messaging/ProducerModel.cs
+++ b/src/SmiServices/Common/Messaging/ProducerModel.cs
@@ -91,7 +91,8 @@ namespace SmiServices.Common.Messaging
 
             while (keepTrying)
             {
-                bool ok = _model.WaitForConfirms(TimeSpan.FromMilliseconds(ConfirmTimeoutMs), out var timedOut);
+                if (_model.WaitForConfirms(TimeSpan.FromMilliseconds(ConfirmTimeoutMs), out var timedOut))
+                    return;
 
                 if (timedOut)
                 {
@@ -100,10 +101,6 @@ namespace SmiServices.Common.Messaging
 
                     continue;
                 }
-
-                // All good
-                if (ok)
-                    return;
 
                 throw new ApplicationException("RabbitMQ got a Nack");
             }

--- a/src/SmiServices/Common/Messaging/StaticBackoffProvider.cs
+++ b/src/SmiServices/Common/Messaging/StaticBackoffProvider.cs
@@ -4,14 +4,14 @@ namespace SmiServices.Common.Messaging
 {
     public class StaticBackoffProvider : IBackoffProvider
     {
-        private readonly TimeSpan _backoff;
+        private readonly TimeSpan _initialBackoff;
 
-        public StaticBackoffProvider(TimeSpan? backoff = null)
+        public StaticBackoffProvider(TimeSpan? initialBackoff = null)
         {
-            _backoff = backoff ?? new TimeSpan(hours: 0, minutes: 1, seconds: 0);
+            _initialBackoff = initialBackoff ?? new TimeSpan(hours: 0, minutes: 1, seconds: 0);
         }
 
-        public TimeSpan GetNextBackoff() => _backoff;
+        public TimeSpan GetNextBackoff() => _initialBackoff;
 
         public void Reset() { }
     }

--- a/src/SmiServices/Common/Messaging/StaticBackoffProvider.cs
+++ b/src/SmiServices/Common/Messaging/StaticBackoffProvider.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace SmiServices.Common.Messaging
+{
+    public class StaticBackoffProvider : IBackoffProvider
+    {
+        private readonly TimeSpan _backoff;
+
+        public StaticBackoffProvider(TimeSpan? backoff = null)
+        {
+            _backoff = backoff ?? new TimeSpan(hours: 0, minutes: 1, seconds: 0);
+        }
+
+        public TimeSpan GetNextBackoff() => _backoff;
+
+        public void Reset() { }
+    }
+}

--- a/src/SmiServices/Common/Options/ProducerOptions.cs
+++ b/src/SmiServices/Common/Options/ProducerOptions.cs
@@ -1,4 +1,5 @@
 using Equ;
+using SmiServices.Common.Messaging;
 
 namespace SmiServices.Common.Options
 {
@@ -18,6 +19,11 @@ namespace SmiServices.Common.Options
         public int MaxConfirmAttempts { get; set; } = 1;
 
         /// <summary>
+        /// Specify the <see cref="IBackoffProvider"/> to use when handling publish failures
+        /// </summary>
+        public string? BackoffProviderType { get; set; }
+
+        /// <summary>
         /// Verifies that the individual options have been populated
         /// </summary>
         /// <returns></returns>
@@ -26,9 +32,6 @@ namespace SmiServices.Common.Options
             return !string.IsNullOrWhiteSpace(ExchangeName);
         }
 
-        public override string ToString()
-        {
-            return "ExchangeName: " + ExchangeName + ", MaxConfirmAttempts: " + MaxConfirmAttempts;
-        }
+        public override string ToString() => $"ExchangeName={ExchangeName}, MaxConfirmAttempts={MaxConfirmAttempts}, BackoffProviderType={BackoffProviderType}";
     }
 }

--- a/tests/SmiServices.IntegrationTests/Common/Messaging/RabbitMQBrokerTests.cs
+++ b/tests/SmiServices.IntegrationTests/Common/Messaging/RabbitMQBrokerTests.cs
@@ -272,6 +272,70 @@ namespace SmiServices.UnitTests.Common.Messaging
             });
         }
 
+        [Test]
+        public void SetupProducer_NullBackoffProvider_DoesNotThrow()
+        {
+            // Arrange
+
+            var exchangeName = $"TEST.{nameof(SetupProducer_NullBackoffProvider_DoesNotThrow)}Exchange";
+            _tester.CreateExchange(exchangeName);
+
+            var producerOptions = new ProducerOptions
+            {
+                ExchangeName = exchangeName,
+                BackoffProviderType = null,
+            };
+
+            var broker = new RabbitMQBroker(_testOptions.RabbitOptions!, "RabbitMqAdapterTests");
+
+            // Act
+            // Assert
+            Assert.DoesNotThrow(() => broker.SetupProducer(producerOptions));
+        }
+
+        [Test]
+        public void SetupProducer_InvalidBackoffProvider_Throws()
+        {
+            // Arrange
+
+            var exchangeName = $"TEST.{nameof(SetupProducer_InvalidBackoffProvider_Throws)}Exchange";
+            _tester.CreateExchange(exchangeName);
+
+            var producerOptions = new ProducerOptions
+            {
+                ExchangeName = exchangeName,
+                BackoffProviderType = "Foo",
+            };
+
+            var broker = new RabbitMQBroker(_testOptions.RabbitOptions!, "RabbitMqAdapterTests");
+
+            // Act
+            // Assert
+            var exc = Assert.Throws<ArgumentException>(() => broker.SetupProducer(producerOptions));
+            Assert.That(exc.Message, Is.EqualTo("Could not parse 'Foo' to a valid BackoffProviderType"));
+        }
+
+        [Test]
+        public void SetupProducer_ValidBackoffProvider()
+        {
+            // Arrange
+
+            var exchangeName = $"TEST.{nameof(SetupProducer_InvalidBackoffProvider_Throws)}Exchange";
+            _tester.CreateExchange(exchangeName);
+
+            var producerOptions = new ProducerOptions
+            {
+                ExchangeName = exchangeName,
+                BackoffProviderType = "StaticBackoffProvider",
+            };
+
+            var broker = new RabbitMQBroker(_testOptions.RabbitOptions!, "RabbitMqAdapterTests");
+
+            // Act
+            // Assert
+            Assert.DoesNotThrow(() => broker.SetupProducer(producerOptions));
+        }
+
         private class ThrowingConsumer : Consumer<TestMessage>
         {
             public int HeldMessages { get => _heldMessages; }

--- a/tests/SmiServices.UnitTests/Common/Messaging/ExponentialBackoffProviderTests.cs
+++ b/tests/SmiServices.UnitTests/Common/Messaging/ExponentialBackoffProviderTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using SmiServices.Common.Messaging;
+using System;
+
+namespace SmiServices.UnitTests.Common.Messaging;
+
+internal class ExponentialBackoffProviderTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        TestLogger.Setup();
+    }
+
+    [Test]
+    public void GetNextBackoff_ReturnsIncreasingTimeSpan()
+    {
+        var provider = new ExponentialBackoffProvider(new TimeSpan(1));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1)));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(2)));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(4)));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(8)));
+    }
+
+    [Test]
+    public void Reset_ReturnsTimeoutToInitial()
+    {
+        var provider = new ExponentialBackoffProvider(new TimeSpan(1));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1)));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(2)));
+        provider.Reset();
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1)));
+    }
+}

--- a/tests/SmiServices.UnitTests/Common/Messaging/ExponentialBackoffProviderTests.cs
+++ b/tests/SmiServices.UnitTests/Common/Messaging/ExponentialBackoffProviderTests.cs
@@ -13,6 +13,22 @@ internal class ExponentialBackoffProviderTests
     }
 
     [Test]
+    public void Constructor_WithTimeSpan_IsSet()
+    {
+        var provider = new ExponentialBackoffProvider(new TimeSpan(1, 2, 3));
+
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1, 2, 3)));
+    }
+
+    [Test]
+    public void Constructor_WithNoTimeSpan_UsesDefault()
+    {
+        var provider = new ExponentialBackoffProvider();
+
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(0, 1, 0)));
+    }
+
+    [Test]
     public void GetNextBackoff_ReturnsIncreasingTimeSpan()
     {
         var provider = new ExponentialBackoffProvider(new TimeSpan(1));

--- a/tests/SmiServices.UnitTests/Common/Messaging/ProducerModelTests.cs
+++ b/tests/SmiServices.UnitTests/Common/Messaging/ProducerModelTests.cs
@@ -1,0 +1,62 @@
+using Moq;
+using NUnit.Framework;
+using RabbitMQ.Client;
+using SmiServices.Common.Messages;
+using SmiServices.Common.Messaging;
+using System;
+using System.Collections.Generic;
+
+namespace SmiServices.UnitTests.Common.Messaging;
+
+internal class ProducerModelTests
+{
+    private class TestMessage : IMessage { }
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        TestLogger.Setup();
+    }
+
+    [Test]
+    public void SendMessage_HappyPath()
+    {
+        // Arrange
+        bool timedOut = false;
+        var mockModel = new Mock<IModel>(MockBehavior.Strict);
+        mockModel.Setup(x => x.BasicPublish("Exchange", "", true, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()));
+        mockModel.Setup(x => x.WaitForConfirms(It.IsAny<TimeSpan>(), out timedOut)).Returns(true);
+
+        var mockBasicProperties = new Mock<IBasicProperties>();
+        mockBasicProperties.Setup(x => x.Headers).Returns(new Dictionary<string, object>());
+
+        var producerModel = new ProducerModel("Exchange", mockModel.Object, mockBasicProperties.Object);
+        var message = new TestMessage();
+
+        // Act
+        // Assert
+        Assert.DoesNotThrow(() => producerModel.SendMessage(message, inResponseTo: null, routingKey: null));
+    }
+
+    [Test]
+    public void SendMessage_ThrowsException_OnTimeout()
+    {
+        // Arrange
+        bool timedOut = true;
+        var mockModel = new Mock<IModel>(MockBehavior.Strict);
+        mockModel.Setup(x => x.BasicPublish("Exchange", "", true, It.IsAny<IBasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>()));
+        mockModel.Setup(x => x.WaitForConfirms(It.IsAny<TimeSpan>(), out timedOut)).Returns(false);
+
+        var mockBasicProperties = new Mock<IBasicProperties>();
+        mockBasicProperties.Setup(x => x.Headers).Returns(new Dictionary<string, object>());
+
+        var maxRetryAttempts = 1;
+        var producerModel = new ProducerModel("Exchange", mockModel.Object, mockBasicProperties.Object, maxRetryAttempts);
+        var message = new TestMessage();
+
+        // Act
+        // Assert
+        var exc = Assert.Throws<ApplicationException>(() => producerModel.SendMessage(message, inResponseTo: null, routingKey: null));
+        Assert.That(exc.Message, Is.EqualTo("Could not confirm message published after timeout"));
+    }
+}

--- a/tests/SmiServices.UnitTests/Common/Messaging/ProducerModelTests.cs
+++ b/tests/SmiServices.UnitTests/Common/Messaging/ProducerModelTests.cs
@@ -30,12 +30,18 @@ internal class ProducerModelTests
         var mockBasicProperties = new Mock<IBasicProperties>();
         mockBasicProperties.Setup(x => x.Headers).Returns(new Dictionary<string, object>());
 
-        var producerModel = new ProducerModel("Exchange", mockModel.Object, mockBasicProperties.Object);
+        var mockBackoffProvider = new Mock<IBackoffProvider>(MockBehavior.Strict);
+        mockBackoffProvider.Setup(x => x.GetNextBackoff()).Returns(TimeSpan.Zero);
+        mockBackoffProvider.Setup(x => x.Reset()).Verifiable();
+
+        var maxRetryAttempts = 1;
+        var producerModel = new ProducerModel("Exchange", mockModel.Object, mockBasicProperties.Object, maxRetryAttempts, mockBackoffProvider.Object);
         var message = new TestMessage();
 
         // Act
         // Assert
         Assert.DoesNotThrow(() => producerModel.SendMessage(message, inResponseTo: null, routingKey: null));
+        mockBackoffProvider.Verify();
     }
 
     [Test]
@@ -50,8 +56,11 @@ internal class ProducerModelTests
         var mockBasicProperties = new Mock<IBasicProperties>();
         mockBasicProperties.Setup(x => x.Headers).Returns(new Dictionary<string, object>());
 
+        var mockBackoffProvider = new Mock<IBackoffProvider>(MockBehavior.Strict);
+        mockBackoffProvider.Setup(x => x.GetNextBackoff()).Returns(TimeSpan.Zero);
+
         var maxRetryAttempts = 1;
-        var producerModel = new ProducerModel("Exchange", mockModel.Object, mockBasicProperties.Object, maxRetryAttempts);
+        var producerModel = new ProducerModel("Exchange", mockModel.Object, mockBasicProperties.Object, maxRetryAttempts, mockBackoffProvider.Object);
         var message = new TestMessage();
 
         // Act

--- a/tests/SmiServices.UnitTests/Common/Messaging/StaticBackoffProviderTests.cs
+++ b/tests/SmiServices.UnitTests/Common/Messaging/StaticBackoffProviderTests.cs
@@ -12,11 +12,19 @@ internal class StaticBackoffProviderTests
     }
 
     [Test]
-    public void Constructor_TimeSpan()
+    public void Constructor_WithTimeSpan_IsSet()
     {
         var provider = new StaticBackoffProvider(new TimeSpan(1, 2, 3));
 
         Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1, 2, 3)));
+    }
+
+    [Test]
+    public void Constructor_WithNoTimeSpan_UsesDefault()
+    {
+        var provider = new StaticBackoffProvider();
+
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(0, 1, 0)));
     }
 
     [Test]

--- a/tests/SmiServices.UnitTests/Common/Messaging/StaticBackoffProviderTests.cs
+++ b/tests/SmiServices.UnitTests/Common/Messaging/StaticBackoffProviderTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using SmiServices.Common.Messaging;
+using System;
+
+namespace SmiServices.UnitTests.Common.Messaging;
+internal class StaticBackoffProviderTests
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        TestLogger.Setup();
+    }
+
+    [Test]
+    public void Constructor_TimeSpan()
+    {
+        var provider = new StaticBackoffProvider(new TimeSpan(1, 2, 3));
+
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1, 2, 3)));
+    }
+
+    [Test]
+    public void GetNextBackoff_ReturnsStaticTimeSpan()
+    {
+        var provider = new StaticBackoffProvider(new TimeSpan(1));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1)));
+        Assert.That(provider.GetNextBackoff(), Is.EqualTo(new TimeSpan(1)));
+    }
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Summarise your proposed changes here, including any notes for reviewers -->

Add a publish timeout backoff mechanism to ProducerModel, allowing control over message publishing timeout behaviour. This can be enabled by setting `BackoffProviderType` in any `ProducerOptions` config. Currently implemented types are:

- StaticBackoffProvider (1 minute flat timeout)
- ExponentialBackoffProvider (1 minute initial, doubling after each timeout)

We can make the timeout values and limits configurable in a future PR.

## Types of changes

<!-- What types of changes does your code introduce? Tick all that apply. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update (if none of the other choices apply)
  - In this case, ensure that the message of the head commit from the source branch is prefixed with `[skip ci]`

## Checklist

By opening this PR, I confirm that I have:

- [x] Reviewed the [contributing](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTING.md) guidelines for this repository
- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
- [x] Updated any relevant API documentation
- [x] Created or updated any tests if relevant
- [x] Created a [news](https://github.com/SMI/SmiServices/blob/main/news/README.md) file
  - NOTE: This **_must_** include any changes to any of the following files: default.yaml, any of the RabbitMQ server configurations, GlobalOptions.cs
- [x] Listed myself in the [CONTRIBUTORS](https://github.com/SMI/SmiServices/blob/main/CONTRIBUTORS.md) file 🚀
- [x] Requested a review by the `@SMI/Reviewers` team

## Issues

<!-- If relevant, tag any issues that are _expected_ to be resolved with this PR. E.g.: -->
